### PR TITLE
Publish the payload JSON Schema, and normalize the format it exposed

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,8 @@
 - [ ] No host-specific references introduced (the CI guard and `HostAgnosticBoundaryTests` enforce this)
 - [ ] Public API changes are reflected in `docs/`
 - [ ] A behavior change to the interpreter or the reader/writer has a test that fails without it
-- [ ] If the on-disk format changed, the JSON Schema and its version were updated together
+- [ ] If the on-disk format changed, the JSON Schema and `BpmnPayloadFormat.Version` were updated together
+      (regenerate with `dotnet run --project tools/Bpmn.Schema.Generator -- .`; `PayloadSchemaTests` fails if you forget)
 
 ## BPMN conformance
 

--- a/.github/scripts/check-host-agnostic.py
+++ b/.github/scripts/check-host-agnostic.py
@@ -32,7 +32,7 @@ FORBIDDEN = re.compile(r"elsa", re.IGNORECASE)
 ALLOW_START = re.compile(r"host-agnostic-allow:", re.IGNORECASE)
 ALLOW_END = re.compile(r"host-agnostic-allow-end", re.IGNORECASE)
 
-SEARCH_ROOTS = ["src", "tests", "samples", "docs"]
+SEARCH_ROOTS = ["src", "tests", "samples", "docs", "tools"]
 ROOT_FILES = ["README.md", "CONTRIBUTING.md"]
 EXTENSIONS = {".cs", ".csproj", ".props", ".md", ".yml", ".json", ".bpmn", ".slnx"}
 

--- a/Bpmn.slnx
+++ b/Bpmn.slnx
@@ -5,6 +5,9 @@
     <Project Path="src/Bpmn.Semantics/Bpmn.Semantics.csproj" />
     <Project Path="src/Bpmn.Runtime.InMemory/Bpmn.Runtime.InMemory.csproj" />
   </Folder>
+  <Folder Name="/tools/">
+    <Project Path="tools/Bpmn.Schema.Generator/Bpmn.Schema.Generator.csproj" />
+  </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Bpmn.Model.Tests/Bpmn.Model.Tests.csproj" />
     <Project Path="tests/Bpmn.Interchange.Tests/Bpmn.Interchange.Tests.csproj" />

--- a/docs/adr/0005-the-library-owns-a-versioned-payload-format.md
+++ b/docs/adr/0005-the-library-owns-a-versioned-payload-format.md
@@ -1,6 +1,6 @@
 # ADR 0005: The library owns a versioned payload format
 
-**Status**: Accepted
+**Status**: Accepted (implemented)
 **Date**: 2026-08-09
 
 ## Context
@@ -38,6 +38,36 @@ The nested document is identical across hosts. The envelope is each host's own b
 
 Non-.NET consumers generate their types from the published schema rather than mirroring the model by
 hand.
+
+## Implementation
+
+Shipped, after this ADR spent a while describing something that did not exist.
+
+- `BpmnPayloadFormat.Version` is the format version, separate from the package version. A consumer pins
+  to it; the package version moves for unrelated reasons.
+- `src/Bpmn.Model/schema/bpmn-payload.schema.json` is generated from the model and checked in, so a
+  format change shows up as a schema diff in review. It is packed into `Bpmn.Model` under `schema/`,
+  which is what makes "published as a build artifact" literally true.
+- `tools/Bpmn.Schema.Generator` produces it by reflecting over the model. It describes what
+  `System.Text.Json` actually writes, not what the C# types look like.
+- `PayloadSchemaTests` regenerates and compares on every test run, and cross-checks the schema against
+  real serializer output, so the artifact cannot rot.
+
+### What publishing it exposed
+
+Generating the schema immediately found a defect the prose had been hiding: **the format uses two
+naming conventions.** The definition side names properties in camelCase through explicit
+`[JsonPropertyName]` attributes. The whole of `Bpmn.Model.State` carries no such attributes, so it
+serializes under CLR names, PascalCase. `BpmnProcessDefinition.Extensions` is a one-off outlier on the
+definition side, inconsistent with its own sibling in the same file. Fifty-three properties in total.
+
+That is precisely the class of thing this ADR predicted a hand-written mirror would get wrong, and it
+was in the format itself the whole time.
+
+The schema describes reality rather than the intent, because a schema that flatters the model is worse
+than none. The format version is therefore **0.1.0** rather than 1.0.0: calling it 1.0.0 would freeze
+the inconsistency into a contract on the day it was found. Normalizing the names is cheap now, while
+the library is pre-1.0 with a single consumer, and expensive later.
 
 ## Consequences
 

--- a/docs/adr/0005-the-library-owns-a-versioned-payload-format.md
+++ b/docs/adr/0005-the-library-owns-a-versioned-payload-format.md
@@ -54,9 +54,9 @@ Shipped, after this ADR spent a while describing something that did not exist.
   real serializer output for both roots, so the artifact cannot rot.
 
 The format covers two documents, not one: a definition and the execution state of a running instance.
-The schema's own `$ref` describes the first, so validating a bare `bpmn-payload.schema.json` validates a
-definition; the second is `bpmn-payload.schema.json#/$defs/bpmnExecutionState`. Both are listed under
-`x-roots` so a code generator does not have to know those names.
+The schema root uses a `oneOf` over both, so a standard validator accepts either document when resolving
+`bpmn-payload.schema.json` directly. Both are also listed under `x-roots` so a code generator does not
+have to know the individual `$defs` names.
 
 ### What publishing it exposed
 

--- a/docs/adr/0005-the-library-owns-a-versioned-payload-format.md
+++ b/docs/adr/0005-the-library-owns-a-versioned-payload-format.md
@@ -51,23 +51,38 @@ Shipped, after this ADR spent a while describing something that did not exist.
 - `tools/Bpmn.Schema.Generator` produces it by reflecting over the model. It describes what
   `System.Text.Json` actually writes, not what the C# types look like.
 - `PayloadSchemaTests` regenerates and compares on every test run, and cross-checks the schema against
-  real serializer output, so the artifact cannot rot.
+  real serializer output for both roots, so the artifact cannot rot.
+
+The format covers two documents, not one: a definition and the execution state of a running instance.
+The schema's own `$ref` describes the first, so validating a bare `bpmn-payload.schema.json` validates a
+definition; the second is `bpmn-payload.schema.json#/$defs/bpmnExecutionState`. Both are listed under
+`x-roots` so a code generator does not have to know those names.
 
 ### What publishing it exposed
 
-Generating the schema immediately found a defect the prose had been hiding: **the format uses two
-naming conventions.** The definition side names properties in camelCase through explicit
-`[JsonPropertyName]` attributes. The whole of `Bpmn.Model.State` carries no such attributes, so it
-serializes under CLR names, PascalCase. `BpmnProcessDefinition.Extensions` is a one-off outlier on the
+Generating the schema immediately found a defect the prose had been hiding: **the format used two
+naming conventions.** The definition side named properties in camelCase through explicit
+`[JsonPropertyName]` attributes. The whole of `Bpmn.Model.State` carried no such attributes, so it
+serialized under CLR names, PascalCase. `BpmnProcessDefinition.Extensions` was a one-off outlier on the
 definition side, inconsistent with its own sibling in the same file. Fifty-three properties in total.
 
 That is precisely the class of thing this ADR predicted a hand-written mirror would get wrong, and it
-was in the format itself the whole time.
+was in the format itself the whole time. Nothing was checking, because nothing had ever written the
+format down.
 
-The schema describes reality rather than the intent, because a schema that flatters the model is worse
-than none. The format version is therefore **0.1.0** rather than 1.0.0: calling it 1.0.0 would freeze
-the inconsistency into a contract on the day it was found. Normalizing the names is cheap now, while
-the library is pre-1.0 with a single consumer, and expensive later.
+The names were normalized to camelCase before the format was frozen, and the version is **1.0.0**
+rather than something below 1.0 to say that it is frozen. The alternative — publishing the
+inconsistency and deferring the fix — was considered and rejected: the cost of normalizing is bounded
+now, while the library is pre-1.0 with no schema behind it, and unbounded once consumers have generated
+types from a 1.0 contract, at which point the same change breaks every language at once. The one thing
+worse than a format with a wart is a format whose first published version enshrines it.
+
+The wire format for `Bpmn.Model.State` therefore changed: state persisted by `0.1.x` does not
+deserialize. Nothing had shipped against a published schema, so there was nothing to migrate.
+
+Explicitness is now the enforced rule, not a convention. Every serialized property declares its wire
+name, and `Model_declares_every_serialized_name` fails on any that does not — because the failure mode
+here was never a wrong name, it was a property nobody had named at all.
 
 ## Consequences
 

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -113,9 +113,9 @@ Three things a consumer generating types should know, all of them described in t
   rather than relying on a default, and a test fails on any that does not — generating the schema found
   53 properties that had drifted to PascalCase, and they were normalized before the format was frozen.
   See ADR 0005.
-- **There are two roots.** `bpmn-payload.schema.json` describes a definition;
-  `bpmn-payload.schema.json#/$defs/bpmnExecutionState` describes the execution state of a running
-  instance. Both are listed under `x-roots`.
+- **There are two roots.** The schema root uses a `oneOf` over both `bpmnDefinitions` and
+  `bpmnExecutionState`, so a standard validator accepts either document directly when resolving
+  `bpmn-payload.schema.json`. Both are also listed under `x-roots` as a convenience for code generators.
 
 Regenerate the schema after any model change:
 

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -87,7 +87,7 @@ can paste into a bug report.
 ### The serialization is owned and versioned
 
 `Bpmn.Model` owns the JSON serialization of the model rather than leaving it to each host, and
-publishes a JSON Schema for it as a build artifact. Hosts **wrap** rather than replace it: a host that
+publishes a JSON Schema for it. Hosts **wrap** rather than replace it: a host that
 needs to attach its own data puts the library-owned document inside its own envelope.
 
 ```json
@@ -100,6 +100,19 @@ needs to attach its own data puts the library-owned document inside its own enve
 The nested document is identical across hosts, and non-.NET consumers generate their types from the
 published schema instead of hand-mirroring the model. Treat the format as a public contract — see
 [ADR 0005](../adr/0005-the-library-owns-a-versioned-payload-format.md).
+
+The schema ships inside the `Bpmn.Model` package at `schema/bpmn-payload.schema.json`, and lives in the
+repository at `src/Bpmn.Model/schema/`. `BpmnPayloadFormat.Version` is the format version, which is
+**not** the package version: pin to the former.
+
+Two things a consumer generating types should know, because both are easy to get wrong by hand and both
+are described accurately in the schema:
+
+- **Enums are integers.** The model declares no `JsonStringEnumConverter`, so every enum crosses the
+  wire as a number. The schema publishes the names alongside as `x-enumNames`.
+- **Property naming is not uniform yet.** The definition side is camelCase; everything under
+  `Bpmn.Model.State` is PascalCase. Generate from the schema rather than assuming a convention. This is
+  a known defect, recorded in ADR 0005, and is why the format version is still below 1.0.
 
 ## `Bpmn.Interchange`
 

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -105,14 +105,23 @@ The schema ships inside the `Bpmn.Model` package at `schema/bpmn-payload.schema.
 repository at `src/Bpmn.Model/schema/`. `BpmnPayloadFormat.Version` is the format version, which is
 **not** the package version: pin to the former.
 
-Two things a consumer generating types should know, because both are easy to get wrong by hand and both
-are described accurately in the schema:
+Three things a consumer generating types should know, all of them described in the schema itself:
 
 - **Enums are integers.** The model declares no `JsonStringEnumConverter`, so every enum crosses the
   wire as a number. The schema publishes the names alongside as `x-enumNames`.
-- **Property naming is not uniform yet.** The definition side is camelCase; everything under
-  `Bpmn.Model.State` is PascalCase. Generate from the schema rather than assuming a convention. This is
-  a known defect, recorded in ADR 0005, and is why the format version is still below 1.0.
+- **Properties are camelCase**, uniformly. Every serialized property declares its wire name explicitly
+  rather than relying on a default, and a test fails on any that does not — generating the schema found
+  53 properties that had drifted to PascalCase, and they were normalized before the format was frozen.
+  See ADR 0005.
+- **There are two roots.** `bpmn-payload.schema.json` describes a definition;
+  `bpmn-payload.schema.json#/$defs/bpmnExecutionState` describes the execution state of a running
+  instance. Both are listed under `x-roots`.
+
+Regenerate the schema after any model change:
+
+```bash
+dotnet run --project tools/Bpmn.Schema.Generator -- .
+```
 
 ## `Bpmn.Interchange`
 

--- a/src/Bpmn.Model/Bpmn.Model.csproj
+++ b/src/Bpmn.Model/Bpmn.Model.csproj
@@ -2,4 +2,15 @@
   <PropertyGroup>
     <Description>The neutral BPMN 2.0 object model: processes, flow elements, sequence flows, event definitions, DI layout, retained vendor extensions, and the versioned on-disk format. No dependencies.</Description>
   </PropertyGroup>
+
+  <!--
+    ADR 0005 promises the JSON Schema is published as a build artifact. Shipping it inside the package
+    is what makes that literally true: a consumer who takes the NuGet package has the schema, and a
+    non-.NET consumer can generate types from it instead of hand-mirroring the model.
+
+    The file is generated and checked in; see tools/Bpmn.Schema.Generator for how to regenerate it.
+  -->
+  <ItemGroup>
+    <None Include="schema/bpmn-payload.schema.json" Pack="true" PackagePath="schema/" Visible="true" />
+  </ItemGroup>
 </Project>

--- a/src/Bpmn.Model/BpmnDefinitions.cs
+++ b/src/Bpmn.Model/BpmnDefinitions.cs
@@ -105,6 +105,7 @@ public sealed record BpmnProcessDefinition(
     public IReadOnlyList<BpmnVariableDeclaration> Variables { get; init; } = Variables ?? [];
 
     /// <summary>Foreign XML retained from the process element. Never null.</summary>
+    [JsonPropertyName("extensions")]
     public BpmnExtensions Extensions { get; init; } = Extensions ?? BpmnExtensions.Empty;
 }
 

--- a/src/Bpmn.Model/BpmnPayloadFormat.cs
+++ b/src/Bpmn.Model/BpmnPayloadFormat.cs
@@ -1,0 +1,46 @@
+namespace Bpmn.Model;
+
+/// <summary>
+/// The identity of this library's on-disk payload format.
+/// <para>
+/// The format is a public contract, versioned independently of the package. A consumer pins to
+/// <see cref="Version"/>; the NuGet package version moves for reasons that have nothing to do with the
+/// shape of a serialized document, so it is the wrong thing to pin to. See ADR 0005.
+/// </para>
+/// <para>
+/// This version changes only when the serialized shape changes. Adding an optional property with a
+/// default that round-trips is a minor bump; renaming, removing, or changing the meaning of a property
+/// is a major one. The published JSON Schema carries this version in its <c>$id</c>, so a schema diff
+/// and a version bump are the same review.
+/// </para>
+/// </summary>
+public static class BpmnPayloadFormat
+{
+    /// <summary>
+    /// The current payload format version, as a semantic version string.
+    /// <para>
+    /// Deliberately below 1.0. Publishing the schema surfaced a real inconsistency in the format: the
+    /// definition side names its properties in camelCase through explicit attributes, while the whole of
+    /// <c>Bpmn.Model.State</c> carries no attributes and therefore serializes PascalCase, and
+    /// <c>BpmnProcessDefinition.Extensions</c> is a one-off outlier on the definition side. That is 53
+    /// properties following the wrong one of two conventions in a single document.
+    /// </para>
+    /// <para>
+    /// The schema describes the format as it actually is, because a schema that flatters the model is
+    /// worse than none. But calling that 1.0.0 would freeze the inconsistency into a contract on the day
+    /// it was discovered. 0.1.0 says what is true: described, versioned, and not yet frozen.
+    /// </para>
+    /// </summary>
+    public const string Version = "0.1.0";
+
+    /// <summary>
+    /// The <c>$id</c> of the published JSON Schema describing this format.
+    /// </summary>
+    public const string SchemaId = "https://valence.works/schemas/bpmn/payload/" + Version + ".json";
+
+    /// <summary>
+    /// The file name of the published schema, as it appears in the <c>Bpmn.Model</c> package under
+    /// <c>schema/</c> and in the repository under <c>src/Bpmn.Model/schema/</c>.
+    /// </summary>
+    public const string SchemaFileName = "bpmn-payload.schema.json";
+}

--- a/src/Bpmn.Model/BpmnPayloadFormat.cs
+++ b/src/Bpmn.Model/BpmnPayloadFormat.cs
@@ -19,19 +19,21 @@ public static class BpmnPayloadFormat
     /// <summary>
     /// The current payload format version, as a semantic version string.
     /// <para>
-    /// Deliberately below 1.0. Publishing the schema surfaced a real inconsistency in the format: the
-    /// definition side names its properties in camelCase through explicit attributes, while the whole of
-    /// <c>Bpmn.Model.State</c> carries no attributes and therefore serializes PascalCase, and
-    /// <c>BpmnProcessDefinition.Extensions</c> is a one-off outlier on the definition side. That is 53
-    /// properties following the wrong one of two conventions in a single document.
+    /// Publishing the schema surfaced a real inconsistency: the definition side named its properties in
+    /// camelCase through explicit attributes, while the whole of <c>Bpmn.Model.State</c> carried none and
+    /// therefore serialized PascalCase, with <c>BpmnProcessDefinition.Extensions</c> a one-off outlier on
+    /// the definition side. Fifty-three properties following the wrong one of two conventions in a single
+    /// document.
     /// </para>
     /// <para>
-    /// The schema describes the format as it actually is, because a schema that flatters the model is
-    /// worse than none. But calling that 1.0.0 would freeze the inconsistency into a contract on the day
-    /// it was discovered. 0.1.0 says what is true: described, versioned, and not yet frozen.
+    /// Those names were normalized to camelCase before the format was frozen, which is why this is 1.0.0
+    /// rather than something below 1.0. Normalizing cost a day while the library was pre-1.0 with no
+    /// published schema behind it; the same change after consumers had generated types from a 1.0 contract
+    /// would have been a breaking change in every language at once. Every serialized property now declares
+    /// its wire name explicitly, and <c>Model_declares_every_serialized_name</c> keeps it that way.
     /// </para>
     /// </summary>
-    public const string Version = "0.1.0";
+    public const string Version = "1.0.0";
 
     /// <summary>
     /// The <c>$id</c> of the published JSON Schema describing this format.

--- a/src/Bpmn.Model/State/BpmnActiveWork.cs
+++ b/src/Bpmn.Model/State/BpmnActiveWork.cs
@@ -26,10 +26,16 @@ public sealed record BpmnActiveWork
     }
 
     /// <summary>The executable node id of the scheduled child activity.</summary>
+    [JsonPropertyName("nodeId")]
     public string NodeId { get; init; }
 
+    [JsonPropertyName("elementId")]
     public string ElementId { get; init; }
+
+    [JsonPropertyName("tokenId")]
     public string TokenId { get; init; }
+
+    [JsonPropertyName("schedulingCause")]
     public string SchedulingCause { get; init; }
 
     /// <summary>
@@ -37,5 +43,6 @@ public sealed record BpmnActiveWork
     /// for ordinary single-run children. A teardown resolves this child's live activity-execution id from the
     /// <c>(NodeId, IterationId)</c> live-child map so N concurrent same-node instances resolve distinctly.
     /// </summary>
+    [JsonPropertyName("iterationId")]
     public string? IterationId { get; init; }
 }

--- a/src/Bpmn.Model/State/BpmnCompensable.cs
+++ b/src/Bpmn.Model/State/BpmnCompensable.cs
@@ -30,14 +30,18 @@ public sealed record BpmnCompensable
     }
 
     /// <summary>The registration id (a pure function of <c>Sequence</c>); reverse-registration replay orders by descending id.</summary>
+    [JsonPropertyName("compensableId")]
     public string CompensableId { get; init; }
 
     /// <summary>The host element whose completion was registered.</summary>
+    [JsonPropertyName("hostElementId")]
     public string HostElementId { get; init; }
 
     /// <summary>The compensation handler element replayed for this registration.</summary>
+    [JsonPropertyName("handlerElementId")]
     public string HandlerElementId { get; init; }
 
+    [JsonPropertyName("status")]
     public BpmnCompensableStatus Status { get; init; }
 }
 

--- a/src/Bpmn.Model/State/BpmnCompensationRun.cs
+++ b/src/Bpmn.Model/State/BpmnCompensationRun.cs
@@ -27,11 +27,14 @@ public sealed record BpmnCompensationRun
     }
 
     /// <summary>The run record id (a pure function of <c>Sequence</c>).</summary>
+    [JsonPropertyName("runId")]
     public string RunId { get; init; }
 
     /// <summary>The compensate throw/end token that coordinates this run (stays <c>AwaitingChild</c> until the run finishes).</summary>
+    [JsonPropertyName("throwTokenId")]
     public string ThrowTokenId { get; init; }
 
     /// <summary>The still-to-run claimed compensables, ordered <b>descending by registration</b> (reverse completion order); the head is the currently running handler.</summary>
+    [JsonPropertyName("pendingCompensableIds")]
     public IReadOnlyList<string> PendingCompensableIds { get; init; }
 }

--- a/src/Bpmn.Model/State/BpmnDiagnosticEvent.cs
+++ b/src/Bpmn.Model/State/BpmnDiagnosticEvent.cs
@@ -26,12 +26,25 @@ public sealed record BpmnDiagnosticEvent
         Details = details ?? new Dictionary<string, string>();
     }
 
+    [JsonPropertyName("diagnosticId")]
     public string DiagnosticId { get; init; }
+
+    [JsonPropertyName("kind")]
     public BpmnDiagnosticKind Kind { get; init; }
+
+    [JsonPropertyName("message")]
     public string Message { get; init; }
+
+    [JsonPropertyName("elementId")]
     public string? ElementId { get; init; }
+
+    [JsonPropertyName("flowId")]
     public string? FlowId { get; init; }
+
+    [JsonPropertyName("tokenId")]
     public string? TokenId { get; init; }
+
+    [JsonPropertyName("details")]
     public IReadOnlyDictionary<string, string> Details { get; init; }
 }
 

--- a/src/Bpmn.Model/State/BpmnEventRace.cs
+++ b/src/Bpmn.Model/State/BpmnEventRace.cs
@@ -7,7 +7,7 @@ namespace Bpmn.Model.State;
 /// member token per outbound flow (each arriving at an intermediate catch event that arms). The first
 /// member whose child completes wins and routes; every other member token is cancelled and its armed child
 /// subtree torn down. <see cref="RaceId"/> derives from <c>BpmnExecutionState.Sequence</c> (the only id
-/// source); the record is additive payload growth — the state schema stays version 1.
+/// source).
 /// </summary>
 public sealed record BpmnEventRace
 {

--- a/src/Bpmn.Model/State/BpmnEventRace.cs
+++ b/src/Bpmn.Model/State/BpmnEventRace.cs
@@ -27,12 +27,17 @@ public sealed record BpmnEventRace
         Resolved = resolved;
     }
 
+    [JsonPropertyName("raceId")]
     public string RaceId { get; init; }
+
+    [JsonPropertyName("gatewayElementId")]
     public string GatewayElementId { get; init; }
 
     /// <summary>The tokens the gateway minted onto its outbound flows; exactly one wins, the rest are cancelled.</summary>
+    [JsonPropertyName("memberTokenIds")]
     public IReadOnlyCollection<string> MemberTokenIds { get; init; }
 
     /// <summary>Set once the first member's child completed and the losing siblings were cancelled.</summary>
+    [JsonPropertyName("resolved")]
     public bool Resolved { get; init; }
 }

--- a/src/Bpmn.Model/State/BpmnExecutionState.cs
+++ b/src/Bpmn.Model/State/BpmnExecutionState.cs
@@ -36,24 +36,36 @@ public sealed record BpmnExecutionState
         Cancelling = cancelling;
     }
 
+    [JsonPropertyName("tokens")]
     public IReadOnlyCollection<BpmnToken> Tokens { get; init; }
+
+    [JsonPropertyName("activeWork")]
     public IReadOnlyCollection<BpmnActiveWork> ActiveWork { get; init; }
+
+    [JsonPropertyName("diagnostics")]
     public IReadOnlyCollection<BpmnDiagnosticEvent> Diagnostics { get; init; }
+
+    [JsonPropertyName("sequence")]
     public int Sequence { get; init; }
 
     /// <summary>The open/resolved first-catch-wins races opened by event-based gateways; additive, schema stays v1.</summary>
+    [JsonPropertyName("races")]
     public IReadOnlyCollection<BpmnEventRace> Races { get; init; }
 
     /// <summary>The live multi-instance loops; each is a coordinator token with private per-instance sub-tokens. Additive, schema stays v1.</summary>
+    [JsonPropertyName("loops")]
     public IReadOnlyCollection<BpmnLoopState> Loops { get; init; }
 
     /// <summary>The durable reverse-order compensation log; each host completion carrying an attached compensation boundary is registered here. Never pruned. Additive, schema stays v1.</summary>
+    [JsonPropertyName("compensables")]
     public IReadOnlyCollection<BpmnCompensable> Compensables { get; init; }
 
     /// <summary>The in-flight compensation replay runs; each is a compensate throw/end coordinator token replaying its claimed handlers sequentially. Additive, schema stays v1.</summary>
+    [JsonPropertyName("compensationRuns")]
     public IReadOnlyCollection<BpmnCompensationRun> CompensationRuns { get; init; }
 
     /// <summary>Set when a terminate end event ended the process; late child completions are ignored.</summary>
+    [JsonPropertyName("terminated")]
     public bool Terminated { get; init; }
 
     /// <summary>
@@ -62,6 +74,7 @@ public sealed record BpmnExecutionState
     /// <c>Cancelled</c> outcome (parallel to <see cref="Terminated"/>, but completing with a distinct outcome
     /// rather than <c>Done</c>). Additive, schema stays v1.
     /// </summary>
+    [JsonPropertyName("cancelling")]
     public bool Cancelling { get; init; }
 
     /// <summary>
@@ -69,6 +82,7 @@ public sealed record BpmnExecutionState
     /// evaluation had already staged child schedules (the runtime forbids terminal decisions that also
     /// schedule children). The next callback surfaces it.
     /// </summary>
+    [JsonPropertyName("pendingFault")]
     public BpmnPendingFault? PendingFault { get; init; }
 
     /// <summary>The maximum number of diagnostics <see cref="Prune"/> retains; the oldest are dropped first.</summary>
@@ -106,4 +120,6 @@ public sealed record BpmnExecutionState
 }
 
 /// <summary>A deferred fault decision carried on the execution state (see <see cref="BpmnExecutionState.PendingFault"/>).</summary>
-public sealed record BpmnPendingFault(string FaultCode, string Message);
+public sealed record BpmnPendingFault(
+    [property: JsonPropertyName("faultCode")] string FaultCode,
+    [property: JsonPropertyName("message")] string Message);

--- a/src/Bpmn.Model/State/BpmnExecutionState.cs
+++ b/src/Bpmn.Model/State/BpmnExecutionState.cs
@@ -3,9 +3,9 @@ using System.Text.Json.Serialization;
 namespace Bpmn.Model.State;
 
 /// <summary>
-/// The BPMN engine's typed, versioned private-state envelope payload (<c>bpmn.execution.state</c>,
-/// schema version 1). All record ids are a pure function of <see cref="Sequence"/>; the only mutation
-/// home is <c>BpmnStateMutator</c>.
+/// The BPMN engine's typed, versioned private-state envelope payload (<c>bpmn.execution.state</c>).
+/// All record ids are a pure function of <see cref="Sequence"/>; the only mutation home is
+/// <c>BpmnStateMutator</c>.
 /// </summary>
 public sealed record BpmnExecutionState
 {
@@ -48,19 +48,19 @@ public sealed record BpmnExecutionState
     [JsonPropertyName("sequence")]
     public int Sequence { get; init; }
 
-    /// <summary>The open/resolved first-catch-wins races opened by event-based gateways; additive, schema stays v1.</summary>
+    /// <summary>The open/resolved first-catch-wins races opened by event-based gateways.</summary>
     [JsonPropertyName("races")]
     public IReadOnlyCollection<BpmnEventRace> Races { get; init; }
 
-    /// <summary>The live multi-instance loops; each is a coordinator token with private per-instance sub-tokens. Additive, schema stays v1.</summary>
+    /// <summary>The live multi-instance loops; each is a coordinator token with private per-instance sub-tokens.</summary>
     [JsonPropertyName("loops")]
     public IReadOnlyCollection<BpmnLoopState> Loops { get; init; }
 
-    /// <summary>The durable reverse-order compensation log; each host completion carrying an attached compensation boundary is registered here. Never pruned. Additive, schema stays v1.</summary>
+    /// <summary>The durable reverse-order compensation log; each host completion carrying an attached compensation boundary is registered here. Never pruned.</summary>
     [JsonPropertyName("compensables")]
     public IReadOnlyCollection<BpmnCompensable> Compensables { get; init; }
 
-    /// <summary>The in-flight compensation replay runs; each is a compensate throw/end coordinator token replaying its claimed handlers sequentially. Additive, schema stays v1.</summary>
+    /// <summary>The in-flight compensation replay runs; each is a compensate throw/end coordinator token replaying its claimed handlers sequentially.</summary>
     [JsonPropertyName("compensationRuns")]
     public IReadOnlyCollection<BpmnCompensationRun> CompensationRuns { get; init; }
 
@@ -72,7 +72,7 @@ public sealed record BpmnExecutionState
     /// Set when a cancel end event began cancelling a transaction scope: all other live work is
     /// stopped, the registered compensables are replayed, and the process then completes with the
     /// <c>Cancelled</c> outcome (parallel to <see cref="Terminated"/>, but completing with a distinct outcome
-    /// rather than <c>Done</c>). Additive, schema stays v1.
+    /// rather than <c>Done</c>).
     /// </summary>
     [JsonPropertyName("cancelling")]
     public bool Cancelling { get; init; }

--- a/src/Bpmn.Model/State/BpmnLoopState.cs
+++ b/src/Bpmn.Model/State/BpmnLoopState.cs
@@ -6,10 +6,10 @@ namespace Bpmn.Model.State;
 /// <summary>
 /// The live state of one multi-instance loop. A coordinator token
 /// (<see cref="TokenId"/>) stays <c>AwaitingChild</c> at the host <see cref="ElementId"/> while its instance
-/// sub-tokens run the bound child; this record tracks how many instances remain. It is additive engine state
-/// (schema stays version 1) whose only mutation home is <c>BpmnStateMutator</c>; <see cref="LoopId"/> and the
-/// instance token ids derive from <c>BpmnExecutionState.Sequence</c>. The record is dropped when the loop
-/// completes or its coordinator is cancelled.
+/// sub-tokens run the bound child; this record tracks how many instances remain. The only mutation home is
+/// <c>BpmnStateMutator</c>; <see cref="LoopId"/> and the instance token ids derive from
+/// <c>BpmnExecutionState.Sequence</c>. The record is dropped when the loop completes or its coordinator is
+/// cancelled.
 /// </summary>
 public sealed record BpmnLoopState
 {
@@ -71,7 +71,7 @@ public sealed record BpmnLoopState
     /// value seeded under the host's <c>ItemVariable</c> for instance <c>k</c>. <c>null</c> in cardinality mode.
     /// Persisted on the record because sequential mode seeds instance <c>k+1</c> in a later evaluation (instance
     /// <c>k</c>'s completion) and the snapshot semantics forbid re-reading the variable; parallel mode reads the
-    /// same record for uniformity. Additive state growth (schema stays version 1).
+    /// same record for uniformity.
     /// </summary>
     [JsonPropertyName("items")]
     public IReadOnlyList<JsonElement>? Items { get; init; }

--- a/src/Bpmn.Model/State/BpmnLoopState.cs
+++ b/src/Bpmn.Model/State/BpmnLoopState.cs
@@ -39,24 +39,31 @@ public sealed record BpmnLoopState
     }
 
     /// <summary>The loop record id (a pure function of <c>Sequence</c>).</summary>
+    [JsonPropertyName("loopId")]
     public string LoopId { get; init; }
 
     /// <summary>The coordinator token id: it stays <c>AwaitingChild</c> at <see cref="ElementId"/> while instances run.</summary>
+    [JsonPropertyName("tokenId")]
     public string TokenId { get; init; }
 
     /// <summary>The multi-instance host element id.</summary>
+    [JsonPropertyName("elementId")]
     public string ElementId { get; init; }
 
     /// <summary><c>true</c> = one instance at a time; <c>false</c> = all instances scheduled up front.</summary>
+    [JsonPropertyName("isSequential")]
     public bool IsSequential { get; init; }
 
     /// <summary>The total number of instances the loop runs.</summary>
+    [JsonPropertyName("totalCount")]
     public int TotalCount { get; init; }
 
     /// <summary>The next zero-based instance index to schedule (sequential mode advances this per completion).</summary>
+    [JsonPropertyName("nextIndex")]
     public int NextIndex { get; init; }
 
     /// <summary>How many instances have completed; the loop finishes when this reaches <see cref="TotalCount"/>.</summary>
+    [JsonPropertyName("completedCount")]
     public int CompletedCount { get; init; }
 
     /// <summary>
@@ -66,5 +73,6 @@ public sealed record BpmnLoopState
     /// <c>k</c>'s completion) and the snapshot semantics forbid re-reading the variable; parallel mode reads the
     /// same record for uniformity. Additive state growth (schema stays version 1).
     /// </summary>
+    [JsonPropertyName("items")]
     public IReadOnlyList<JsonElement>? Items { get; init; }
 }

--- a/src/Bpmn.Model/State/BpmnToken.cs
+++ b/src/Bpmn.Model/State/BpmnToken.cs
@@ -34,16 +34,24 @@ public sealed record BpmnToken
         Kind = kind;
     }
 
+    [JsonPropertyName("tokenId")]
     public string TokenId { get; init; }
+
+    [JsonPropertyName("atElementId")]
     public string AtElementId { get; init; }
 
     /// <summary>The sequence flow the token arrived on, or <c>null</c> for start-event tokens.</summary>
+    [JsonPropertyName("flowId")]
     public string? FlowId { get; init; }
 
+    [JsonPropertyName("parentTokenId")]
     public string? ParentTokenId { get; init; }
+
+    [JsonPropertyName("status")]
     public BpmnTokenStatus Status { get; init; }
 
     /// <summary>The unit of host work whose completion produced this token, when known.</summary>
+    [JsonPropertyName("producingWorkHandle")]
     public string? ProducingWorkHandle { get; init; }
 
     /// <summary>
@@ -53,6 +61,7 @@ public sealed record BpmnToken
     /// every other minting site inherits its source/parent/group token's key. Join accounting groups arrivals
     /// by <c>(element, iteration key)</c> so a revisited join never conflates one iteration with the next.
     /// </summary>
+    [JsonPropertyName("iterationKey")]
     public string? IterationKey { get; init; }
 
     /// <summary>
@@ -65,6 +74,7 @@ public sealed record BpmnToken
     /// <see cref="BpmnTokenStatus.AwaitingChild"/> token that is excluded from the completion/deadlock liveness view so
     /// it never blocks the scope from completing.
     /// </summary>
+    [JsonPropertyName("kind")]
     public BpmnTokenKind? Kind { get; init; }
 }
 

--- a/src/Bpmn.Model/schema/bpmn-payload.schema.json
+++ b/src/Bpmn.Model/schema/bpmn-payload.schema.json
@@ -1,0 +1,1409 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://valence.works/schemas/bpmn/payload/0.1.0.json",
+  "title": "BPMN payload format",
+  "description": "Version 0.1.0 of the payload format owned by Bpmn.Model. Generated from the model; do not edit by hand. See ADR 0005.",
+  "x-payloadFormatVersion": "0.1.0",
+  "$ref": "#/$defs/bpmnDefinitions",
+  "$defs": {
+    "bpmnActiveWork": {
+      "type": "object",
+      "title": "BpmnActiveWork",
+      "properties": {
+        "NodeId": {
+          "type": "string"
+        },
+        "ElementId": {
+          "type": "string"
+        },
+        "TokenId": {
+          "type": "string"
+        },
+        "SchedulingCause": {
+          "type": "string"
+        },
+        "IterationId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "NodeId",
+        "ElementId",
+        "TokenId",
+        "SchedulingCause"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnBounds": {
+      "type": "object",
+      "title": "BpmnBounds",
+      "properties": {
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        },
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "width",
+        "height"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnCollaboration": {
+      "type": "object",
+      "title": "BpmnCollaboration",
+      "properties": {
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnPool"
+          }
+        },
+        "messageFlows": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnMessageFlow"
+          }
+        },
+        "extensions": {
+          "$ref": "#/$defs/bpmnExtensions"
+        }
+      },
+      "required": [
+        "pools",
+        "messageFlows",
+        "extensions"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnCompensable": {
+      "type": "object",
+      "title": "BpmnCompensable",
+      "properties": {
+        "CompensableId": {
+          "type": "string"
+        },
+        "HostElementId": {
+          "type": "string"
+        },
+        "HandlerElementId": {
+          "type": "string"
+        },
+        "Status": {
+          "$ref": "#/$defs/bpmnCompensableStatus"
+        }
+      },
+      "required": [
+        "CompensableId",
+        "HostElementId",
+        "HandlerElementId",
+        "Status"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnCompensableStatus": {
+      "type": "integer",
+      "title": "BpmnCompensableStatus",
+      "description": "Serialized as an integer: the model declares no JsonStringEnumConverter.",
+      "enum": [
+        0,
+        1,
+        2
+      ],
+      "x-enumNames": [
+        "Registered",
+        "Claimed",
+        "Compensated"
+      ]
+    },
+    "bpmnCompensationRun": {
+      "type": "object",
+      "title": "BpmnCompensationRun",
+      "properties": {
+        "RunId": {
+          "type": "string"
+        },
+        "ThrowTokenId": {
+          "type": "string"
+        },
+        "PendingCompensableIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "RunId",
+        "ThrowTokenId",
+        "PendingCompensableIds"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnDefinitions": {
+      "type": "object",
+      "title": "BpmnDefinitions",
+      "properties": {
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "targetNamespace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "exporter": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "exporterVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "collaboration": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/bpmnCollaboration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "processes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnProcessDefinition"
+          }
+        },
+        "diagrams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnDiagram"
+          }
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnMessageDeclaration"
+          }
+        },
+        "signals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnSignalDeclaration"
+          }
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnErrorDeclaration"
+          }
+        },
+        "escalations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnEscalationDeclaration"
+          }
+        },
+        "extensions": {
+          "$ref": "#/$defs/bpmnExtensions"
+        }
+      },
+      "required": [
+        "processes",
+        "diagrams",
+        "messages",
+        "signals",
+        "errors",
+        "escalations",
+        "extensions"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnDiagnosticEvent": {
+      "type": "object",
+      "title": "BpmnDiagnosticEvent",
+      "properties": {
+        "DiagnosticId": {
+          "type": "string"
+        },
+        "Kind": {
+          "$ref": "#/$defs/bpmnDiagnosticKind"
+        },
+        "Message": {
+          "type": "string"
+        },
+        "ElementId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "FlowId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "TokenId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Details": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "DiagnosticId",
+        "Kind",
+        "Message",
+        "Details"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnDiagnosticKind": {
+      "type": "integer",
+      "title": "BpmnDiagnosticKind",
+      "description": "Serialized as an integer: the model declares no JsonStringEnumConverter.",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23
+      ],
+      "x-enumNames": [
+        "TokenEmitted",
+        "Scheduled",
+        "Waiting",
+        "Joined",
+        "Consumed",
+        "Canceled",
+        "Terminated",
+        "BehaviorFailure",
+        "Completed",
+        "Faulted",
+        "CompensationRegistered",
+        "CompensationTriggered",
+        "Compensated",
+        "TransactionCancelled",
+        "EscalationRaised",
+        "EscalationCaught",
+        "EscalationUnhandled",
+        "EscalationLate",
+        "EventSubprocessActivated",
+        "EventSubprocessCompleted",
+        "CallActivityFailureRouted",
+        "ScopeListenerArmed",
+        "ScopeListenerFired",
+        "ScopeListenerRetired"
+      ]
+    },
+    "bpmnDiagram": {
+      "type": "object",
+      "title": "BpmnDiagram",
+      "properties": {
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "plane": {
+          "$ref": "#/$defs/bpmnPlane"
+        }
+      },
+      "required": [
+        "plane"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnDocumentation": {
+      "type": "object",
+      "title": "BpmnDocumentation",
+      "properties": {
+        "text": {
+          "type": "string"
+        },
+        "textFormat": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnEdge": {
+      "type": "object",
+      "title": "BpmnEdge",
+      "properties": {
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "bpmnElementRef": {
+          "type": "string"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/bpmnLabel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "waypoints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnPoint"
+          }
+        }
+      },
+      "required": [
+        "bpmnElementRef",
+        "waypoints"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnElement": {
+      "type": "object",
+      "title": "BpmnElement",
+      "properties": {
+        "elementId": {
+          "type": "string"
+        },
+        "elementType": {
+          "type": "string"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "bindingRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "laneId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "defaultFlowId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "eventDefinitions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnEventDefinition"
+          }
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "attachedToRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cancelActivity": {
+          "type": "boolean"
+        },
+        "loopCharacteristics": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/bpmnLoopCharacteristics"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "isForCompensation": {
+          "type": "boolean"
+        },
+        "compensationHandlerElementId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "isTransaction": {
+          "type": "boolean"
+        },
+        "triggeredByEvent": {
+          "type": "boolean"
+        },
+        "listenerBindingRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "extensions": {
+          "$ref": "#/$defs/bpmnExtensions"
+        }
+      },
+      "required": [
+        "elementId",
+        "elementType",
+        "eventDefinitions",
+        "properties",
+        "cancelActivity",
+        "isForCompensation",
+        "isTransaction",
+        "triggeredByEvent",
+        "extensions"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnErrorDeclaration": {
+      "type": "object",
+      "title": "BpmnErrorDeclaration",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "errorCode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnEscalationDeclaration": {
+      "type": "object",
+      "title": "BpmnEscalationDeclaration",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "escalationCode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnEventDefinition": {
+      "type": "object",
+      "title": "BpmnEventDefinition",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "type",
+        "properties"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnEventRace": {
+      "type": "object",
+      "title": "BpmnEventRace",
+      "properties": {
+        "RaceId": {
+          "type": "string"
+        },
+        "GatewayElementId": {
+          "type": "string"
+        },
+        "MemberTokenIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Resolved": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "RaceId",
+        "GatewayElementId",
+        "MemberTokenIds",
+        "Resolved"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnExecutionState": {
+      "type": "object",
+      "title": "BpmnExecutionState",
+      "properties": {
+        "Tokens": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnToken"
+          }
+        },
+        "ActiveWork": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnActiveWork"
+          }
+        },
+        "Diagnostics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnDiagnosticEvent"
+          }
+        },
+        "Sequence": {
+          "type": "integer"
+        },
+        "Races": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnEventRace"
+          }
+        },
+        "Loops": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnLoopState"
+          }
+        },
+        "Compensables": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnCompensable"
+          }
+        },
+        "CompensationRuns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnCompensationRun"
+          }
+        },
+        "Terminated": {
+          "type": "boolean"
+        },
+        "Cancelling": {
+          "type": "boolean"
+        },
+        "PendingFault": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/bpmnPendingFault"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "Tokens",
+        "ActiveWork",
+        "Diagnostics",
+        "Sequence",
+        "Races",
+        "Loops",
+        "Compensables",
+        "CompensationRuns",
+        "Terminated",
+        "Cancelling"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnExtensionElement": {
+      "type": "object",
+      "title": "BpmnExtensionElement",
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/bpmnQName"
+        },
+        "value": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "attributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnForeignAttribute"
+          }
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnExtensionElement"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "attributes",
+        "children"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnExtensions": {
+      "type": "object",
+      "title": "BpmnExtensions",
+      "properties": {
+        "documentation": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnDocumentation"
+          }
+        },
+        "extensionElements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnExtensionElement"
+          }
+        },
+        "foreignAttributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnForeignAttribute"
+          }
+        },
+        "foreignChildren": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnForeignChild"
+          }
+        }
+      },
+      "required": [
+        "documentation",
+        "extensionElements",
+        "foreignAttributes",
+        "foreignChildren"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnForeignAttribute": {
+      "type": "object",
+      "title": "BpmnForeignAttribute",
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/bpmnQName"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnForeignChild": {
+      "type": "object",
+      "title": "BpmnForeignChild",
+      "properties": {
+        "element": {
+          "$ref": "#/$defs/bpmnExtensionElement"
+        },
+        "index": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "element",
+        "index"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnLabel": {
+      "type": "object",
+      "title": "BpmnLabel",
+      "properties": {
+        "bounds": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/bpmnBounds"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "bpmnLane": {
+      "type": "object",
+      "title": "BpmnLane",
+      "properties": {
+        "laneId": {
+          "type": "string"
+        },
+        "poolId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "extensions": {
+          "$ref": "#/$defs/bpmnExtensions"
+        }
+      },
+      "required": [
+        "laneId",
+        "extensions"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnLoopCharacteristics": {
+      "type": "object",
+      "title": "BpmnLoopCharacteristics",
+      "properties": {
+        "isSequential": {
+          "type": "boolean"
+        },
+        "cardinality": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "collectionVariable": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "itemVariable": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "isSequential",
+        "itemVariable"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnLoopState": {
+      "type": "object",
+      "title": "BpmnLoopState",
+      "properties": {
+        "LoopId": {
+          "type": "string"
+        },
+        "TokenId": {
+          "type": "string"
+        },
+        "ElementId": {
+          "type": "string"
+        },
+        "IsSequential": {
+          "type": "boolean"
+        },
+        "TotalCount": {
+          "type": "integer"
+        },
+        "NextIndex": {
+          "type": "integer"
+        },
+        "CompletedCount": {
+          "type": "integer"
+        },
+        "Items": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {}
+        }
+      },
+      "required": [
+        "LoopId",
+        "TokenId",
+        "ElementId",
+        "IsSequential",
+        "TotalCount",
+        "NextIndex",
+        "CompletedCount"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnMessageDeclaration": {
+      "type": "object",
+      "title": "BpmnMessageDeclaration",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnMessageFlow": {
+      "type": "object",
+      "title": "BpmnMessageFlow",
+      "properties": {
+        "flowId": {
+          "type": "string"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sourceElementId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sourcePoolId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "targetElementId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "targetPoolId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "messageName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "extensions": {
+          "$ref": "#/$defs/bpmnExtensions"
+        }
+      },
+      "required": [
+        "flowId",
+        "extensions"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnPendingFault": {
+      "type": "object",
+      "title": "BpmnPendingFault",
+      "properties": {
+        "FaultCode": {
+          "type": "string"
+        },
+        "Message": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "FaultCode",
+        "Message"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnPlane": {
+      "type": "object",
+      "title": "BpmnPlane",
+      "properties": {
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "bpmnElementRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "shapes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnShape"
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnEdge"
+          }
+        }
+      },
+      "required": [
+        "shapes",
+        "edges"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnPoint": {
+      "type": "object",
+      "title": "BpmnPoint",
+      "properties": {
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnPool": {
+      "type": "object",
+      "title": "BpmnPool",
+      "properties": {
+        "poolId": {
+          "type": "string"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "processRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "isExecutable": {
+          "type": "boolean"
+        },
+        "extensions": {
+          "$ref": "#/$defs/bpmnExtensions"
+        }
+      },
+      "required": [
+        "poolId",
+        "isExecutable",
+        "extensions"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnProcessDefinition": {
+      "type": "object",
+      "title": "BpmnProcessDefinition",
+      "properties": {
+        "processId": {
+          "type": "string"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "isExecutable": {
+          "type": "boolean"
+        },
+        "isTransaction": {
+          "type": "boolean"
+        },
+        "elements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnElement"
+          }
+        },
+        "sequenceFlows": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnSequenceFlow"
+          }
+        },
+        "lanes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnLane"
+          }
+        },
+        "variables": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bpmnVariableDeclaration"
+          }
+        },
+        "Extensions": {
+          "$ref": "#/$defs/bpmnExtensions"
+        }
+      },
+      "required": [
+        "processId",
+        "isExecutable",
+        "isTransaction",
+        "elements",
+        "sequenceFlows",
+        "lanes",
+        "variables",
+        "Extensions"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnQName": {
+      "type": "object",
+      "title": "BpmnQName",
+      "properties": {
+        "ns": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "localName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "localName"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnSequenceFlow": {
+      "type": "object",
+      "title": "BpmnSequenceFlow",
+      "properties": {
+        "flowId": {
+          "type": "string"
+        },
+        "sourceRef": {
+          "type": "string"
+        },
+        "targetRef": {
+          "type": "string"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "conditionOutcome": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "isDefault": {
+          "type": "boolean"
+        },
+        "extensions": {
+          "$ref": "#/$defs/bpmnExtensions"
+        }
+      },
+      "required": [
+        "flowId",
+        "sourceRef",
+        "targetRef",
+        "isDefault",
+        "extensions"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnShape": {
+      "type": "object",
+      "title": "BpmnShape",
+      "properties": {
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "bpmnElementRef": {
+          "type": "string"
+        },
+        "bounds": {
+          "$ref": "#/$defs/bpmnBounds"
+        },
+        "isHorizontal": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "isExpanded": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "isMarkerVisible": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/bpmnLabel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "bpmnElementRef",
+        "bounds"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnSignalDeclaration": {
+      "type": "object",
+      "title": "BpmnSignalDeclaration",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnToken": {
+      "type": "object",
+      "title": "BpmnToken",
+      "properties": {
+        "TokenId": {
+          "type": "string"
+        },
+        "AtElementId": {
+          "type": "string"
+        },
+        "FlowId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ParentTokenId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Status": {
+          "$ref": "#/$defs/bpmnTokenStatus"
+        },
+        "ProducingWorkHandle": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "IterationKey": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/bpmnTokenKind"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "TokenId",
+        "AtElementId",
+        "Status"
+      ],
+      "additionalProperties": false
+    },
+    "bpmnTokenKind": {
+      "type": "integer",
+      "title": "BpmnTokenKind",
+      "description": "Serialized as an integer: the model declares no JsonStringEnumConverter.",
+      "enum": [
+        0,
+        1
+      ],
+      "x-enumNames": [
+        "Listener",
+        "Activation"
+      ]
+    },
+    "bpmnTokenStatus": {
+      "type": "integer",
+      "title": "BpmnTokenStatus",
+      "description": "Serialized as an integer: the model declares no JsonStringEnumConverter.",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "x-enumNames": [
+        "Active",
+        "AwaitingChild",
+        "WaitingAtJoin",
+        "Consumed",
+        "Canceled"
+      ]
+    },
+    "bpmnVariableDeclaration": {
+      "type": "object",
+      "title": "BpmnVariableDeclaration",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "typeHint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "defaultValue": {}
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/Bpmn.Model/schema/bpmn-payload.schema.json
+++ b/src/Bpmn.Model/schema/bpmn-payload.schema.json
@@ -8,7 +8,14 @@
     "BpmnDefinitions": "#/$defs/bpmnDefinitions",
     "BpmnExecutionState": "#/$defs/bpmnExecutionState"
   },
-  "$ref": "#/$defs/bpmnDefinitions",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/bpmnDefinitions"
+    },
+    {
+      "$ref": "#/$defs/bpmnExecutionState"
+    }
+  ],
   "$defs": {
     "bpmnActiveWork": {
       "type": "object",

--- a/src/Bpmn.Model/schema/bpmn-payload.schema.json
+++ b/src/Bpmn.Model/schema/bpmn-payload.schema.json
@@ -1,28 +1,32 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://valence.works/schemas/bpmn/payload/0.1.0.json",
+  "$id": "https://valence.works/schemas/bpmn/payload/1.0.0.json",
   "title": "BPMN payload format",
-  "description": "Version 0.1.0 of the payload format owned by Bpmn.Model. Generated from the model; do not edit by hand. See ADR 0005.",
-  "x-payloadFormatVersion": "0.1.0",
+  "description": "Version 1.0.0 of the payload format owned by Bpmn.Model. Generated from the model; do not edit by hand. See ADR 0005.",
+  "x-payloadFormatVersion": "1.0.0",
+  "x-roots": {
+    "BpmnDefinitions": "#/$defs/bpmnDefinitions",
+    "BpmnExecutionState": "#/$defs/bpmnExecutionState"
+  },
   "$ref": "#/$defs/bpmnDefinitions",
   "$defs": {
     "bpmnActiveWork": {
       "type": "object",
       "title": "BpmnActiveWork",
       "properties": {
-        "NodeId": {
+        "nodeId": {
           "type": "string"
         },
-        "ElementId": {
+        "elementId": {
           "type": "string"
         },
-        "TokenId": {
+        "tokenId": {
           "type": "string"
         },
-        "SchedulingCause": {
+        "schedulingCause": {
           "type": "string"
         },
-        "IterationId": {
+        "iterationId": {
           "type": [
             "string",
             "null"
@@ -30,10 +34,10 @@
         }
       },
       "required": [
-        "NodeId",
-        "ElementId",
-        "TokenId",
-        "SchedulingCause"
+        "nodeId",
+        "elementId",
+        "tokenId",
+        "schedulingCause"
       ],
       "additionalProperties": false
     },
@@ -99,24 +103,24 @@
       "type": "object",
       "title": "BpmnCompensable",
       "properties": {
-        "CompensableId": {
+        "compensableId": {
           "type": "string"
         },
-        "HostElementId": {
+        "hostElementId": {
           "type": "string"
         },
-        "HandlerElementId": {
+        "handlerElementId": {
           "type": "string"
         },
-        "Status": {
+        "status": {
           "$ref": "#/$defs/bpmnCompensableStatus"
         }
       },
       "required": [
-        "CompensableId",
-        "HostElementId",
-        "HandlerElementId",
-        "Status"
+        "compensableId",
+        "hostElementId",
+        "handlerElementId",
+        "status"
       ],
       "additionalProperties": false
     },
@@ -139,13 +143,13 @@
       "type": "object",
       "title": "BpmnCompensationRun",
       "properties": {
-        "RunId": {
+        "runId": {
           "type": "string"
         },
-        "ThrowTokenId": {
+        "throwTokenId": {
           "type": "string"
         },
-        "PendingCompensableIds": {
+        "pendingCompensableIds": {
           "type": "array",
           "items": {
             "type": "string"
@@ -153,9 +157,9 @@
         }
       },
       "required": [
-        "RunId",
-        "ThrowTokenId",
-        "PendingCompensableIds"
+        "runId",
+        "throwTokenId",
+        "pendingCompensableIds"
       ],
       "additionalProperties": false
     },
@@ -252,34 +256,34 @@
       "type": "object",
       "title": "BpmnDiagnosticEvent",
       "properties": {
-        "DiagnosticId": {
+        "diagnosticId": {
           "type": "string"
         },
-        "Kind": {
+        "kind": {
           "$ref": "#/$defs/bpmnDiagnosticKind"
         },
-        "Message": {
+        "message": {
           "type": "string"
         },
-        "ElementId": {
+        "elementId": {
           "type": [
             "string",
             "null"
           ]
         },
-        "FlowId": {
+        "flowId": {
           "type": [
             "string",
             "null"
           ]
         },
-        "TokenId": {
+        "tokenId": {
           "type": [
             "string",
             "null"
           ]
         },
-        "Details": {
+        "details": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -287,10 +291,10 @@
         }
       },
       "required": [
-        "DiagnosticId",
-        "Kind",
-        "Message",
-        "Details"
+        "diagnosticId",
+        "kind",
+        "message",
+        "details"
       ],
       "additionalProperties": false
     },
@@ -608,27 +612,27 @@
       "type": "object",
       "title": "BpmnEventRace",
       "properties": {
-        "RaceId": {
+        "raceId": {
           "type": "string"
         },
-        "GatewayElementId": {
+        "gatewayElementId": {
           "type": "string"
         },
-        "MemberTokenIds": {
+        "memberTokenIds": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "Resolved": {
+        "resolved": {
           "type": "boolean"
         }
       },
       "required": [
-        "RaceId",
-        "GatewayElementId",
-        "MemberTokenIds",
-        "Resolved"
+        "raceId",
+        "gatewayElementId",
+        "memberTokenIds",
+        "resolved"
       ],
       "additionalProperties": false
     },
@@ -636,58 +640,58 @@
       "type": "object",
       "title": "BpmnExecutionState",
       "properties": {
-        "Tokens": {
+        "tokens": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/bpmnToken"
           }
         },
-        "ActiveWork": {
+        "activeWork": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/bpmnActiveWork"
           }
         },
-        "Diagnostics": {
+        "diagnostics": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/bpmnDiagnosticEvent"
           }
         },
-        "Sequence": {
+        "sequence": {
           "type": "integer"
         },
-        "Races": {
+        "races": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/bpmnEventRace"
           }
         },
-        "Loops": {
+        "loops": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/bpmnLoopState"
           }
         },
-        "Compensables": {
+        "compensables": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/bpmnCompensable"
           }
         },
-        "CompensationRuns": {
+        "compensationRuns": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/bpmnCompensationRun"
           }
         },
-        "Terminated": {
+        "terminated": {
           "type": "boolean"
         },
-        "Cancelling": {
+        "cancelling": {
           "type": "boolean"
         },
-        "PendingFault": {
+        "pendingFault": {
           "anyOf": [
             {
               "$ref": "#/$defs/bpmnPendingFault"
@@ -699,16 +703,16 @@
         }
       },
       "required": [
-        "Tokens",
-        "ActiveWork",
-        "Diagnostics",
-        "Sequence",
-        "Races",
-        "Loops",
-        "Compensables",
-        "CompensationRuns",
-        "Terminated",
-        "Cancelling"
+        "tokens",
+        "activeWork",
+        "diagnostics",
+        "sequence",
+        "races",
+        "loops",
+        "compensables",
+        "compensationRuns",
+        "terminated",
+        "cancelling"
       ],
       "additionalProperties": false
     },
@@ -895,28 +899,28 @@
       "type": "object",
       "title": "BpmnLoopState",
       "properties": {
-        "LoopId": {
+        "loopId": {
           "type": "string"
         },
-        "TokenId": {
+        "tokenId": {
           "type": "string"
         },
-        "ElementId": {
+        "elementId": {
           "type": "string"
         },
-        "IsSequential": {
+        "isSequential": {
           "type": "boolean"
         },
-        "TotalCount": {
+        "totalCount": {
           "type": "integer"
         },
-        "NextIndex": {
+        "nextIndex": {
           "type": "integer"
         },
-        "CompletedCount": {
+        "completedCount": {
           "type": "integer"
         },
-        "Items": {
+        "items": {
           "type": [
             "array",
             "null"
@@ -925,13 +929,13 @@
         }
       },
       "required": [
-        "LoopId",
-        "TokenId",
-        "ElementId",
-        "IsSequential",
-        "TotalCount",
-        "NextIndex",
-        "CompletedCount"
+        "loopId",
+        "tokenId",
+        "elementId",
+        "isSequential",
+        "totalCount",
+        "nextIndex",
+        "completedCount"
       ],
       "additionalProperties": false
     },
@@ -1011,16 +1015,16 @@
       "type": "object",
       "title": "BpmnPendingFault",
       "properties": {
-        "FaultCode": {
+        "faultCode": {
           "type": "string"
         },
-        "Message": {
+        "message": {
           "type": "string"
         }
       },
       "required": [
-        "FaultCode",
-        "Message"
+        "faultCode",
+        "message"
       ],
       "additionalProperties": false
     },
@@ -1152,7 +1156,7 @@
             "$ref": "#/$defs/bpmnVariableDeclaration"
           }
         },
-        "Extensions": {
+        "extensions": {
           "$ref": "#/$defs/bpmnExtensions"
         }
       },
@@ -1164,7 +1168,7 @@
         "sequenceFlows",
         "lanes",
         "variables",
-        "Extensions"
+        "extensions"
       ],
       "additionalProperties": false
     },
@@ -1302,40 +1306,40 @@
       "type": "object",
       "title": "BpmnToken",
       "properties": {
-        "TokenId": {
+        "tokenId": {
           "type": "string"
         },
-        "AtElementId": {
+        "atElementId": {
           "type": "string"
         },
-        "FlowId": {
+        "flowId": {
           "type": [
             "string",
             "null"
           ]
         },
-        "ParentTokenId": {
+        "parentTokenId": {
           "type": [
             "string",
             "null"
           ]
         },
-        "Status": {
+        "status": {
           "$ref": "#/$defs/bpmnTokenStatus"
         },
-        "ProducingWorkHandle": {
+        "producingWorkHandle": {
           "type": [
             "string",
             "null"
           ]
         },
-        "IterationKey": {
+        "iterationKey": {
           "type": [
             "string",
             "null"
           ]
         },
-        "Kind": {
+        "kind": {
           "anyOf": [
             {
               "$ref": "#/$defs/bpmnTokenKind"
@@ -1347,9 +1351,9 @@
         }
       },
       "required": [
-        "TokenId",
-        "AtElementId",
-        "Status"
+        "tokenId",
+        "atElementId",
+        "status"
       ],
       "additionalProperties": false
     },

--- a/tests/Bpmn.Architecture.Tests/HostAgnosticBoundaryTests.cs
+++ b/tests/Bpmn.Architecture.Tests/HostAgnosticBoundaryTests.cs
@@ -118,7 +118,7 @@ public sealed class HostAgnosticBoundaryTests
         var allowStart = new Regex("host-agnostic-allow:", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         var allowEnd = new Regex("host-agnostic-allow-end", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        var searchRoots = new[] { "src", "tests", "samples", "docs" }
+        var searchRoots = new[] { "src", "tests", "samples", "docs", "tools" }
             .Select(folder => Path.Combine(repositoryRoot, folder))
             .Where(Directory.Exists)
             .SelectMany(root => Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))

--- a/tests/Bpmn.Model.Tests/Bpmn.Model.Tests.csproj
+++ b/tests/Bpmn.Model.Tests/Bpmn.Model.Tests.csproj
@@ -13,5 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Bpmn.Model/Bpmn.Model.csproj" />
+    <!-- Build-time only, and test-only here: lets the schema-drift guard regenerate and compare in-process. -->
+    <ProjectReference Include="../../tools/Bpmn.Schema.Generator/Bpmn.Schema.Generator.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Bpmn.Model.Tests/PayloadSchemaTests.cs
+++ b/tests/Bpmn.Model.Tests/PayloadSchemaTests.cs
@@ -1,5 +1,7 @@
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using Bpmn.Model;
 using Bpmn.Model.State;
 using Bpmn.Schema.Generator;
@@ -54,9 +56,7 @@ public sealed class PayloadSchemaTests
         var token = new BpmnToken("t1", "e1", status: BpmnTokenStatus.WaitingAtJoin);
         var written = JsonSerializer.SerializeToNode(token)!.AsObject();
 
-        // Note the PascalCase key: BpmnToken declares no [JsonPropertyName], so the CLR name goes out
-        // verbatim. Asserting "status" here would pass against an assumption and fail against reality.
-        written["Status"]!.GetValue<int>().ShouldBe((int)BpmnTokenStatus.WaitingAtJoin);
+        written["status"]!.GetValue<int>().ShouldBe((int)BpmnTokenStatus.WaitingAtJoin);
 
         var declared = (JsonObject)Defs["bpmnTokenStatus"]!;
         declared["type"]!.GetValue<string>().ShouldBe("integer");
@@ -65,20 +65,68 @@ public sealed class PayloadSchemaTests
     }
 
     /// <summary>
+    /// The format names every property in camelCase, and says so explicitly on every one of them.
+    /// <para>
+    /// Explicitness is the point, not just the casing. With no naming policy configured, a property that
+    /// omits the attribute goes out under its CLR name, and the format silently acquires a PascalCase
+    /// member. That is exactly how <c>Bpmn.Model.State</c> and <c>BpmnProcessDefinition.Extensions</c>
+    /// drifted apart from the rest of the format before the schema existed to show it - 53 properties,
+    /// invisible until something generated a document and looked. This test is what stops the 54th.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void Model_declares_every_serialized_name()
+    {
+        BpmnSchemaGenerator.Generate(out var covered);
+
+        var offending = (
+            from type in covered
+            where !type.IsEnum
+            from property in BpmnSchemaGenerator.SerializedProperties(type)
+            let declared = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name
+            where !IsCamelCase(declared)
+            select declared is null
+                ? $"{type.Name}.{property.Name} declares no [JsonPropertyName], so it is written as \"{property.Name}\""
+                : $"{type.Name}.{property.Name} is written as \"{declared}\", which is not camelCase")
+            .ToArray();
+
+        offending.ShouldBeEmpty(
+            "Every serialized property must carry [JsonPropertyName] with a camelCase name. Without the "
+            + "attribute the property goes out under its CLR name and the payload format acquires a second "
+            + "naming convention.\n  " + string.Join("\n  ", offending));
+    }
+
+    /// <summary>
+    /// Both documents the format covers are addressable. The schema's own <c>$ref</c> can only point at
+    /// one, so a consumer persisting execution state needs <c>x-roots</c> to find the other.
+    /// </summary>
+    [Fact]
+    public void Both_payload_roots_are_addressable()
+    {
+        var roots = (JsonObject)Schema["x-roots"]!;
+
+        roots.Count.ShouldBe(2);
+
+        foreach (var (name, _) in roots)
+            RootSchema(name).ShouldNotBeNull($"x-roots lists '{name}' but it resolves to nothing.");
+    }
+
+    /// <summary>
     /// Every property the serializer emits for a realistic document must be described by the schema.
     /// This is the check that catches a computed get-only property quietly joining the contract, and
     /// it is why <c>additionalProperties: false</c> is safe to publish.
     /// </summary>
-    [Fact]
-    public void Every_property_the_serializer_emits_is_described_by_the_schema()
+    [Theory]
+    [MemberData(nameof(SampleDocuments))]
+    public void Every_property_the_serializer_emits_is_described_by_the_schema(string root, object sample)
     {
-        var document = JsonSerializer.SerializeToNode(SampleDefinitions())!;
+        var document = JsonSerializer.SerializeToNode(sample, sample.GetType())!;
         var undescribed = new List<string>();
 
-        Walk(document, RefTarget((JsonObject)Schema), "$", undescribed);
+        Walk(document, RootSchema(root), "$", undescribed);
 
         undescribed.ShouldBeEmpty(
-            "These paths are written by System.Text.Json but not described by the schema:\n  "
+            $"These paths are written by System.Text.Json for {root} but not described by the schema:\n  "
             + string.Join("\n  ", undescribed));
     }
 
@@ -86,15 +134,25 @@ public sealed class PayloadSchemaTests
     /// The mirror image: a property the schema marks required must actually be written. A required
     /// property the serializer omits would make every real document fail validation.
     /// </summary>
-    [Fact]
-    public void Every_required_property_is_actually_written()
+    [Theory]
+    [MemberData(nameof(SampleDocuments))]
+    public void Every_required_property_is_actually_written(string root, object sample)
     {
-        var document = JsonSerializer.SerializeToNode(SampleDefinitions())!.AsObject();
-        var definition = RefTarget((JsonObject)Schema);
+        var document = JsonSerializer.SerializeToNode(sample, sample.GetType())!.AsObject();
 
-        foreach (var name in Required(definition))
-            document.ContainsKey(name).ShouldBeTrue($"Schema requires '{name}' on the root, but it was not written.");
+        foreach (var name in Required(RootSchema(root)))
+            document.ContainsKey(name).ShouldBeTrue($"Schema requires '{name}' on {root}, but it was not written.");
     }
+
+    /// <summary>
+    /// One sample per payload root. A definition alone would leave the whole of
+    /// <c>Bpmn.Model.State</c> unchecked, which is the half of the format that drifted.
+    /// </summary>
+    public static TheoryData<string, object> SampleDocuments() => new()
+    {
+        { nameof(BpmnDefinitions), SampleDefinitions() },
+        { nameof(BpmnExecutionState), SampleExecutionState() }
+    };
 
     // ---- walking ---------------------------------------------------------------------------------
 
@@ -151,7 +209,17 @@ public sealed class PayloadSchemaTests
         return obj;
     }
 
-    private static JsonObject RefTarget(JsonObject schema) => Resolve(schema)!;
+    /// <summary>
+    /// A wire name is checked for the convention, not for being mechanically derived from the CLR name.
+    /// Deliberate renames are legitimate - <c>BpmnQName.Namespace</c> is published as <c>ns</c>, since the
+    /// CLR name only reads that way because <c>namespace</c> is a keyword.
+    /// </summary>
+    private static bool IsCamelCase(string? name) =>
+        !string.IsNullOrEmpty(name) && char.IsLower(name[0]) && name.All(char.IsLetterOrDigit);
+
+    /// <summary>The schema describing one of the payload roots, looked up through <c>x-roots</c>.</summary>
+    private static JsonObject RootSchema(string root) =>
+        Resolve(new JsonObject { ["$ref"] = ((JsonObject)Schema["x-roots"]!)[root]!.DeepClone() })!;
 
     private static IEnumerable<string> Required(JsonObject schema) =>
         schema["required"] is JsonArray required
@@ -183,6 +251,24 @@ public sealed class PayloadSchemaTests
             TargetNamespace: "https://example.test",
             Processes: [process]);
     }
+
+    /// <summary>
+    /// A state document populating every collection on the root, so the walk reaches each record type
+    /// rather than skipping past an empty array.
+    /// </summary>
+    private static BpmnExecutionState SampleExecutionState() =>
+        new(
+            tokens: [new BpmnToken("tok:1", "work", flowId: "flow:1", status: BpmnTokenStatus.AwaitingChild, kind: BpmnTokenKind.Listener)],
+            activeWork: [new BpmnActiveWork("node:1", "work", "tok:1", "sequence-flow", iterationId: "iter:1")],
+            diagnostics: [new BpmnDiagnosticEvent("diag:1", BpmnDiagnosticKind.Scheduled, "Scheduled work", elementId: "work", details: new Dictionary<string, string> { ["reason"] = "test" })],
+            sequence: 7,
+            terminated: true,
+            pendingFault: new BpmnPendingFault("BPMN-1", "A fault"),
+            races: [new BpmnEventRace("race:1", "gateway", ["tok:1"], resolved: true)],
+            loops: [new BpmnLoopState("loop:1", "tok:1", "work", isSequential: true, totalCount: 2, nextIndex: 1, completedCount: 1, items: [JsonSerializer.SerializeToElement("first")])],
+            compensables: [new BpmnCompensable("comp:1", "work", "undo", BpmnCompensableStatus.Registered)],
+            compensationRuns: [new BpmnCompensationRun("comprun:1", "tok:1", ["comp:1"])],
+            cancelling: true);
 
     private static JsonObject LoadSchema() =>
         (JsonObject)JsonNode.Parse(File.ReadAllText(SchemaPath()))!;

--- a/tests/Bpmn.Model.Tests/PayloadSchemaTests.cs
+++ b/tests/Bpmn.Model.Tests/PayloadSchemaTests.cs
@@ -1,0 +1,204 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Bpmn.Model;
+using Bpmn.Model.State;
+using Bpmn.Schema.Generator;
+using Shouldly;
+using Xunit;
+
+namespace Bpmn.Model.Tests;
+
+/// <summary>
+/// The guard that keeps the published JSON Schema honest.
+/// <para>
+/// A checked-in generated artifact is only worth having if something fails when it goes stale, so the
+/// first test regenerates and compares. The rest cross-check the schema against what
+/// <see cref="JsonSerializer"/> actually writes, because a schema that merely looks plausible is worse
+/// than none: consumers generate types from it and trust the result.
+/// </para>
+/// </summary>
+public sealed class PayloadSchemaTests
+{
+    private static readonly JsonObject Schema = LoadSchema();
+    private static JsonObject Defs => (JsonObject)Schema["$defs"]!;
+
+    [Fact]
+    public void Checked_in_schema_matches_the_generator()
+    {
+        var generated = BpmnSchemaGenerator.Generate();
+        var checkedIn = File.ReadAllText(SchemaPath());
+
+        checkedIn.ShouldBe(
+            generated,
+            "The checked-in schema is stale. Regenerate it with:\n"
+            + "  dotnet run --project tools/Bpmn.Schema.Generator -- .\n"
+            + "and review the diff. A payload change and a schema change are the same review.");
+    }
+
+    [Fact]
+    public void Schema_declares_the_current_format_version()
+    {
+        Schema["x-payloadFormatVersion"]!.GetValue<string>().ShouldBe(BpmnPayloadFormat.Version);
+        Schema["$id"]!.GetValue<string>().ShouldBe(BpmnPayloadFormat.SchemaId);
+        BpmnPayloadFormat.SchemaId.ShouldContain(BpmnPayloadFormat.Version);
+    }
+
+    /// <summary>
+    /// The model declares no <c>JsonStringEnumConverter</c>, so enums go out as integers. This is the
+    /// single most likely thing for a hand-written client mirror to get wrong, so it is asserted
+    /// against real serializer output rather than against the model's declaration.
+    /// </summary>
+    [Fact]
+    public void Enums_are_serialized_as_integers_exactly_as_the_schema_claims()
+    {
+        var token = new BpmnToken("t1", "e1", status: BpmnTokenStatus.WaitingAtJoin);
+        var written = JsonSerializer.SerializeToNode(token)!.AsObject();
+
+        // Note the PascalCase key: BpmnToken declares no [JsonPropertyName], so the CLR name goes out
+        // verbatim. Asserting "status" here would pass against an assumption and fail against reality.
+        written["Status"]!.GetValue<int>().ShouldBe((int)BpmnTokenStatus.WaitingAtJoin);
+
+        var declared = (JsonObject)Defs["bpmnTokenStatus"]!;
+        declared["type"]!.GetValue<string>().ShouldBe("integer");
+        declared["enum"]!.AsArray().Select(x => x!.GetValue<int>())
+            .ShouldContain((int)BpmnTokenStatus.WaitingAtJoin);
+    }
+
+    /// <summary>
+    /// Every property the serializer emits for a realistic document must be described by the schema.
+    /// This is the check that catches a computed get-only property quietly joining the contract, and
+    /// it is why <c>additionalProperties: false</c> is safe to publish.
+    /// </summary>
+    [Fact]
+    public void Every_property_the_serializer_emits_is_described_by_the_schema()
+    {
+        var document = JsonSerializer.SerializeToNode(SampleDefinitions())!;
+        var undescribed = new List<string>();
+
+        Walk(document, RefTarget((JsonObject)Schema), "$", undescribed);
+
+        undescribed.ShouldBeEmpty(
+            "These paths are written by System.Text.Json but not described by the schema:\n  "
+            + string.Join("\n  ", undescribed));
+    }
+
+    /// <summary>
+    /// The mirror image: a property the schema marks required must actually be written. A required
+    /// property the serializer omits would make every real document fail validation.
+    /// </summary>
+    [Fact]
+    public void Every_required_property_is_actually_written()
+    {
+        var document = JsonSerializer.SerializeToNode(SampleDefinitions())!.AsObject();
+        var definition = RefTarget((JsonObject)Schema);
+
+        foreach (var name in Required(definition))
+            document.ContainsKey(name).ShouldBeTrue($"Schema requires '{name}' on the root, but it was not written.");
+    }
+
+    // ---- walking ---------------------------------------------------------------------------------
+
+    private static void Walk(JsonNode? node, JsonObject? schema, string path, List<string> undescribed)
+    {
+        if (node is null || schema is null)
+            return;
+
+        switch (node)
+        {
+            case JsonObject obj when schema["properties"] is JsonObject properties:
+                foreach (var entry in obj)
+                {
+                    if (properties[entry.Key] is not { } propertySchema)
+                    {
+                        undescribed.Add($"{path}.{entry.Key}");
+                        continue;
+                    }
+
+                    Walk(entry.Value, Resolve(propertySchema), $"{path}.{entry.Key}", undescribed);
+                }
+
+                break;
+
+            // A free-form object (additionalProperties describing values, e.g. a string dictionary).
+            case JsonObject obj when schema["additionalProperties"] is JsonObject valueSchema:
+                foreach (var entry in obj)
+                    Walk(entry.Value, Resolve(valueSchema), $"{path}.{entry.Key}", undescribed);
+
+                break;
+
+            case JsonArray array when schema["items"] is { } itemSchema:
+                var resolvedItems = Resolve(itemSchema);
+
+                for (var i = 0; i < array.Count; i++)
+                    Walk(array[i], resolvedItems, $"{path}[{i}]", undescribed);
+
+                break;
+        }
+    }
+
+    /// <summary>Follows a <c>$ref</c> or an <c>anyOf</c> containing one, to the object it describes.</summary>
+    private static JsonObject? Resolve(JsonNode node)
+    {
+        if (node is not JsonObject obj)
+            return null;
+
+        if (obj["$ref"] is { } reference)
+            return Defs[reference.GetValue<string>()["#/$defs/".Length..]] as JsonObject;
+
+        if (obj["anyOf"] is JsonArray anyOf)
+            return anyOf.Select(x => x is null ? null : Resolve(x)).FirstOrDefault(x => x is not null);
+
+        return obj;
+    }
+
+    private static JsonObject RefTarget(JsonObject schema) => Resolve(schema)!;
+
+    private static IEnumerable<string> Required(JsonObject schema) =>
+        schema["required"] is JsonArray required
+            ? required.Select(x => x!.GetValue<string>())
+            : [];
+
+    // ---- fixtures --------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A document deliberately exercising the awkward corners: a dictionary, a nested collection, an
+    /// enum, retained foreign content and diagram interchange.
+    /// </summary>
+    private static BpmnDefinitions SampleDefinitions()
+    {
+        var process = new BpmnProcessBuilder("p1")
+            .Name("Sample")
+            .Variable("items", "any")
+            .StartEvent("start")
+            .ServiceTask("work", "Do work")
+            .ExclusiveGateway("choice")
+            .EndEvent("done")
+            .Connect("start", "work")
+            .Connect("work", "choice")
+            .Connect("choice", "done", isDefault: true)
+            .Build();
+
+        return new BpmnDefinitions(
+            Id: "defs",
+            TargetNamespace: "https://example.test",
+            Processes: [process]);
+    }
+
+    private static JsonObject LoadSchema() =>
+        (JsonObject)JsonNode.Parse(File.ReadAllText(SchemaPath()))!;
+
+    /// <summary>
+    /// Walks up from the test binaries to the repository root. Keyed off the solution file so it does
+    /// not depend on how deep the build output happens to be.
+    /// </summary>
+    private static string SchemaPath()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Bpmn.slnx")))
+            directory = directory.Parent;
+
+        directory.ShouldNotBeNull("Could not locate the repository root from the test output directory.");
+        return Path.Combine(directory!.FullName, "src", "Bpmn.Model", "schema", BpmnPayloadFormat.SchemaFileName);
+    }
+}

--- a/tools/Bpmn.Schema.Generator/Bpmn.Schema.Generator.csproj
+++ b/tools/Bpmn.Schema.Generator/Bpmn.Schema.Generator.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Build-time only. This never ships, so it is free to exist outside the four packages' zero-dependency
+    promise. It has no PackageReferences anyway; the generator is reflection over System.Text.Json.
+  -->
+  <PropertyGroup>
+    <TargetFrameworks></TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <RootNamespace>Bpmn.Schema.Generator</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Bpmn.Model/Bpmn.Model.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Bpmn.Schema.Generator/BpmnSchemaGenerator.cs
+++ b/tools/Bpmn.Schema.Generator/BpmnSchemaGenerator.cs
@@ -27,7 +27,16 @@ namespace Bpmn.Schema.Generator;
 /// </summary>
 public static class BpmnSchemaGenerator
 {
-    /// <summary>The roots a consumer serializes. Everything reachable from them is emitted into <c>$defs</c>.</summary>
+    /// <summary>
+    /// The roots a consumer serializes. Everything reachable from them is emitted into <c>$defs</c>.
+    /// <para>
+    /// There are two, because the format covers two documents: a definition and the execution state of a
+    /// running instance. The schema's own <c>$ref</c> points at the first, since a bare
+    /// <c>bpmn-payload.schema.json</c> should validate a definition; the second is addressed as
+    /// <c>bpmn-payload.schema.json#/$defs/bpmnExecutionState</c>. Both are listed under <c>x-roots</c> so a
+    /// code generator can find them without knowing those names.
+    /// </para>
+    /// </summary>
     private static readonly Type[] Roots =
     [
         typeof(BpmnDefinitions),
@@ -35,11 +44,26 @@ public static class BpmnSchemaGenerator
     ];
 
     /// <summary>Generates the schema document, formatted for a reviewable diff.</summary>
-    public static string Generate()
+    public static string Generate() => Generate(out _);
+
+    /// <summary>
+    /// Generates the schema and reports the type closure it covers - exactly the types that land in
+    /// <c>$defs</c>.
+    /// <para>
+    /// The closure is reported rather than recomputed by callers so that "what the format covers" has a
+    /// single definition. A test asserting a property of the model over a second, hand-maintained list
+    /// would drift from the schema the moment someone added a type, which is the failure this whole
+    /// generator exists to prevent.
+    /// </para>
+    /// </summary>
+    public static string Generate(out IReadOnlyList<Type> covered)
     {
         var defs = new JsonObject();
         var pending = new Queue<Type>(Roots);
         var seen = new HashSet<Type>();
+        var closure = new List<Type>();
+
+        covered = closure;
 
         while (pending.Count > 0)
         {
@@ -48,6 +72,7 @@ public static class BpmnSchemaGenerator
             if (!seen.Add(type))
                 continue;
 
+            closure.Add(type);
             defs[DefName(type)] = type.IsEnum ? DescribeEnum(type) : DescribeObject(type, pending);
         }
 
@@ -66,6 +91,7 @@ public static class BpmnSchemaGenerator
                 $"Version {BpmnPayloadFormat.Version} of the payload format owned by Bpmn.Model. "
                 + "Generated from the model; do not edit by hand. See ADR 0005.",
             ["x-payloadFormatVersion"] = BpmnPayloadFormat.Version,
+            ["x-roots"] = RootPointers(),
             ["$ref"] = Ref(typeof(BpmnDefinitions)),
             ["$defs"] = orderedDefs
         };
@@ -139,9 +165,10 @@ public static class BpmnSchemaGenerator
         if (underlying is not null)
             return Describe(underlying, nullable: true, pending);
 
-        // JsonElement is whatever the host put there. Deliberately unconstrained.
+        // JsonElement is whatever the host put there: any JSON value, including null. Deliberately
+        // unconstrained, so nullability makes no difference to what it accepts.
         if (type == typeof(JsonElement))
-            return nullable ? new JsonObject() : new JsonObject();
+            return new JsonObject();
 
         if (type == typeof(string))
             return Primitive("string", nullable);
@@ -207,7 +234,7 @@ public static class BpmnSchemaGenerator
     /// they are on the wire and therefore part of the contract, whether or not they were intended to be.
     /// </para>
     /// </summary>
-    private static IEnumerable<PropertyInfo> SerializedProperties(Type type) =>
+    public static IEnumerable<PropertyInfo> SerializedProperties(Type type) =>
         type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
             .Where(p => p.GetMethod is not null && p.GetIndexParameters().Length == 0)
             .Where(p => p.GetCustomAttribute<JsonIgnoreAttribute>() is null);
@@ -277,6 +304,21 @@ public static class BpmnSchemaGenerator
 
     private static IEnumerable<Type> Interfaces(Type type) =>
         type.IsInterface ? new[] { type }.Concat(type.GetInterfaces()) : type.GetInterfaces();
+
+    /// <summary>
+    /// The addressable roots, keyed by type name. A consumer generating types needs to know which
+    /// <c>$defs</c> entries are whole documents rather than fragments, and the schema's single
+    /// <c>$ref</c> can only say that about one of them.
+    /// </summary>
+    private static JsonObject RootPointers()
+    {
+        var roots = new JsonObject();
+
+        foreach (var type in Roots)
+            roots[type.Name] = Ref(type);
+
+        return roots;
+    }
 
     private static string Ref(Type type) => "#/$defs/" + DefName(type);
 

--- a/tools/Bpmn.Schema.Generator/BpmnSchemaGenerator.cs
+++ b/tools/Bpmn.Schema.Generator/BpmnSchemaGenerator.cs
@@ -31,10 +31,9 @@ public static class BpmnSchemaGenerator
     /// The roots a consumer serializes. Everything reachable from them is emitted into <c>$defs</c>.
     /// <para>
     /// There are two, because the format covers two documents: a definition and the execution state of a
-    /// running instance. The schema's own <c>$ref</c> points at the first, since a bare
-    /// <c>bpmn-payload.schema.json</c> should validate a definition; the second is addressed as
-    /// <c>bpmn-payload.schema.json#/$defs/bpmnExecutionState</c>. Both are listed under <c>x-roots</c> so a
-    /// code generator can find them without knowing those names.
+    /// running instance. The schema root uses a <c>oneOf</c> over both, so a standard validator accepts
+    /// either document. Both are also listed under <c>x-roots</c> so a code generator can find them without
+    /// knowing the individual <c>$defs</c> names.
     /// </para>
     /// </summary>
     private static readonly Type[] Roots =
@@ -92,7 +91,7 @@ public static class BpmnSchemaGenerator
                 + "Generated from the model; do not edit by hand. See ADR 0005.",
             ["x-payloadFormatVersion"] = BpmnPayloadFormat.Version,
             ["x-roots"] = RootPointers(),
-            ["$ref"] = Ref(typeof(BpmnDefinitions)),
+            ["oneOf"] = RootOneOf(),
             ["$defs"] = orderedDefs
         };
 
@@ -308,7 +307,7 @@ public static class BpmnSchemaGenerator
     /// <summary>
     /// The addressable roots, keyed by type name. A consumer generating types needs to know which
     /// <c>$defs</c> entries are whole documents rather than fragments, and the schema's single
-    /// <c>$ref</c> can only say that about one of them.
+    /// <c>oneOf</c> expresses the same information to a standard validator.
     /// </summary>
     private static JsonObject RootPointers()
     {
@@ -319,6 +318,13 @@ public static class BpmnSchemaGenerator
 
         return roots;
     }
+
+    /// <summary>
+    /// A <c>oneOf</c> array pointing at each root, so a standard JSON Schema validator accepts either
+    /// payload document when it resolves <c>bpmn-payload.schema.json</c> directly.
+    /// </summary>
+    private static JsonArray RootOneOf() =>
+        new(Roots.Select(t => (JsonNode)new JsonObject { ["$ref"] = Ref(t) }).ToArray());
 
     private static string Ref(Type type) => "#/$defs/" + DefName(type);
 

--- a/tools/Bpmn.Schema.Generator/BpmnSchemaGenerator.cs
+++ b/tools/Bpmn.Schema.Generator/BpmnSchemaGenerator.cs
@@ -1,0 +1,284 @@
+using System.Collections;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Bpmn.Model;
+using Bpmn.Model.State;
+
+namespace Bpmn.Schema.Generator;
+
+/// <summary>
+/// Generates the JSON Schema for the library-owned payload format by reflecting over the model.
+/// <para>
+/// It describes what <see cref="JsonSerializer"/> actually writes with default options, not what the
+/// C# types look like to a reader. Those differ in ways that matter, and every one of them is a place
+/// a hand-written mirror drifts:
+/// </para>
+/// <list type="bullet">
+/// <item>The model declares no <c>JsonStringEnumConverter</c>, so enums are written as <b>integers</b>.</item>
+/// <item>Computed get-only properties are serialized too, so they are part of the contract.</item>
+/// <item><c>JsonElement</c> is unconstrained, and <c>JsonElement?</c> is unconstrained or null.</item>
+/// </list>
+/// <para>
+/// Generating rather than hand-writing is the point: the schema cannot disagree with the model,
+/// because it is derived from it.
+/// </para>
+/// </summary>
+public static class BpmnSchemaGenerator
+{
+    /// <summary>The roots a consumer serializes. Everything reachable from them is emitted into <c>$defs</c>.</summary>
+    private static readonly Type[] Roots =
+    [
+        typeof(BpmnDefinitions),
+        typeof(BpmnExecutionState)
+    ];
+
+    /// <summary>Generates the schema document, formatted for a reviewable diff.</summary>
+    public static string Generate()
+    {
+        var defs = new JsonObject();
+        var pending = new Queue<Type>(Roots);
+        var seen = new HashSet<Type>();
+
+        while (pending.Count > 0)
+        {
+            var type = pending.Dequeue();
+
+            if (!seen.Add(type))
+                continue;
+
+            defs[DefName(type)] = type.IsEnum ? DescribeEnum(type) : DescribeObject(type, pending);
+        }
+
+        // $defs is emitted in a stable order so a regenerated schema diffs cleanly against the last one.
+        var orderedDefs = new JsonObject();
+
+        foreach (var entry in defs.OrderBy(x => x.Key, StringComparer.Ordinal))
+            orderedDefs[entry.Key] = entry.Value?.DeepClone();
+
+        var schema = new JsonObject
+        {
+            ["$schema"] = "https://json-schema.org/draft/2020-12/schema",
+            ["$id"] = BpmnPayloadFormat.SchemaId,
+            ["title"] = "BPMN payload format",
+            ["description"] =
+                $"Version {BpmnPayloadFormat.Version} of the payload format owned by Bpmn.Model. "
+                + "Generated from the model; do not edit by hand. See ADR 0005.",
+            ["x-payloadFormatVersion"] = BpmnPayloadFormat.Version,
+            ["$ref"] = Ref(typeof(BpmnDefinitions)),
+            ["$defs"] = orderedDefs
+        };
+
+        return schema.ToJsonString(new JsonSerializerOptions { WriteIndented = true }) + "\n";
+    }
+
+    private static JsonObject DescribeObject(Type type, Queue<Type> pending)
+    {
+        var properties = new JsonObject();
+        var required = new JsonArray();
+
+        foreach (var property in SerializedProperties(type))
+        {
+            var name = JsonNameOf(property);
+            properties[name] = Describe(property.PropertyType, IsNullable(property), pending);
+
+            // A property is required when the serializer always writes it and it can never be null.
+            // Collections are never null in this model (an absent list is an empty list), so they are
+            // required too, which is a real guarantee worth publishing rather than hiding.
+            if (!IsNullable(property))
+                required.Add(name);
+        }
+
+        var described = new JsonObject
+        {
+            ["type"] = "object",
+            ["title"] = type.Name,
+            ["properties"] = properties
+        };
+
+        if (required.Count > 0)
+            described["required"] = required;
+
+        // The model is a closed set of records. Refusing unknown properties turns a typo in a
+        // hand-written document into a validation error rather than a silently ignored field.
+        described["additionalProperties"] = false;
+        return described;
+    }
+
+    /// <summary>
+    /// Enums carry no string converter anywhere in the model, so they are written as integers. The
+    /// names are published alongside as <c>x-enumNames</c> so a code generator can still emit a
+    /// readable type without inventing the mapping.
+    /// </summary>
+    private static JsonObject DescribeEnum(Type type)
+    {
+        var values = new JsonArray();
+        var names = new JsonArray();
+
+        foreach (var value in Enum.GetValues(type))
+        {
+            values.Add(Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture));
+            names.Add(Enum.GetName(type, value));
+        }
+
+        return new JsonObject
+        {
+            ["type"] = "integer",
+            ["title"] = type.Name,
+            ["description"] = "Serialized as an integer: the model declares no JsonStringEnumConverter.",
+            ["enum"] = values,
+            ["x-enumNames"] = names
+        };
+    }
+
+    private static JsonNode Describe(Type type, bool nullable, Queue<Type> pending)
+    {
+        var underlying = Nullable.GetUnderlyingType(type);
+
+        if (underlying is not null)
+            return Describe(underlying, nullable: true, pending);
+
+        // JsonElement is whatever the host put there. Deliberately unconstrained.
+        if (type == typeof(JsonElement))
+            return nullable ? new JsonObject() : new JsonObject();
+
+        if (type == typeof(string))
+            return Primitive("string", nullable);
+
+        if (type == typeof(bool))
+            return Primitive("boolean", nullable);
+
+        if (type == typeof(int) || type == typeof(long))
+            return Primitive("integer", nullable);
+
+        if (type == typeof(double) || type == typeof(decimal) || type == typeof(float))
+            return Primitive("number", nullable);
+
+        if (type.IsEnum)
+        {
+            pending.Enqueue(type);
+            return RefNode(type, nullable);
+        }
+
+        if (TryGetDictionaryValueType(type, out var valueType))
+        {
+            return new JsonObject
+            {
+                ["type"] = nullable ? new JsonArray("object", "null") : "object",
+                ["additionalProperties"] = Describe(valueType, nullable: false, pending)
+            };
+        }
+
+        if (TryGetEnumerableItemType(type, out var itemType))
+        {
+            return new JsonObject
+            {
+                ["type"] = nullable ? new JsonArray("array", "null") : "array",
+                ["items"] = Describe(itemType, nullable: false, pending)
+            };
+        }
+
+        pending.Enqueue(type);
+        return RefNode(type, nullable);
+    }
+
+    private static JsonObject Primitive(string jsonType, bool nullable) =>
+        new() { ["type"] = nullable ? new JsonArray(jsonType, "null") : jsonType };
+
+    /// <summary>
+    /// A nullable reference to a described type. JSON Schema cannot express "null or this $ref" with a
+    /// bare $ref, so a nullable one becomes an anyOf.
+    /// </summary>
+    private static JsonNode RefNode(Type type, bool nullable) =>
+        nullable
+            ? new JsonObject
+            {
+                ["anyOf"] = new JsonArray(
+                    new JsonObject { ["$ref"] = Ref(type) },
+                    new JsonObject { ["type"] = "null" })
+            }
+            : new JsonObject { ["$ref"] = Ref(type) };
+
+    /// <summary>
+    /// Every public instance property the serializer writes, in declaration order.
+    /// <para>
+    /// Get-only computed properties are included deliberately. System.Text.Json serializes them, so
+    /// they are on the wire and therefore part of the contract, whether or not they were intended to be.
+    /// </para>
+    /// </summary>
+    private static IEnumerable<PropertyInfo> SerializedProperties(Type type) =>
+        type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetMethod is not null && p.GetIndexParameters().Length == 0)
+            .Where(p => p.GetCustomAttribute<JsonIgnoreAttribute>() is null);
+
+    /// <summary>
+    /// The name on the wire.
+    /// <para>
+    /// With default <see cref="JsonSerializerOptions"/> there is no naming policy, so a property with no
+    /// <see cref="JsonPropertyNameAttribute"/> is written under its CLR name verbatim, PascalCase and
+    /// all. Assuming camelCase here would produce a schema that quietly disagrees with the serializer,
+    /// which is the exact failure this schema exists to prevent.
+    /// </para>
+    /// </summary>
+    private static string JsonNameOf(PropertyInfo property) =>
+        property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? property.Name;
+
+    private static readonly NullabilityInfoContext Nullability = new();
+
+    private static bool IsNullable(PropertyInfo property)
+    {
+        if (Nullable.GetUnderlyingType(property.PropertyType) is not null)
+            return true;
+
+        if (property.PropertyType.IsValueType)
+            return false;
+
+        return Nullability.Create(property).ReadState is not NullabilityState.NotNull;
+    }
+
+    private static bool TryGetDictionaryValueType(Type type, out Type valueType)
+    {
+        foreach (var candidate in Interfaces(type))
+        {
+            if (!candidate.IsGenericType)
+                continue;
+
+            var definition = candidate.GetGenericTypeDefinition();
+
+            if (definition != typeof(IReadOnlyDictionary<,>) && definition != typeof(IDictionary<,>))
+                continue;
+
+            valueType = candidate.GetGenericArguments()[1];
+            return true;
+        }
+
+        valueType = null!;
+        return false;
+    }
+
+    private static bool TryGetEnumerableItemType(Type type, out Type itemType)
+    {
+        if (type != typeof(string) && typeof(IEnumerable).IsAssignableFrom(type))
+        {
+            foreach (var candidate in Interfaces(type))
+            {
+                if (candidate.IsGenericType && candidate.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                {
+                    itemType = candidate.GetGenericArguments()[0];
+                    return true;
+                }
+            }
+        }
+
+        itemType = null!;
+        return false;
+    }
+
+    private static IEnumerable<Type> Interfaces(Type type) =>
+        type.IsInterface ? new[] { type }.Concat(type.GetInterfaces()) : type.GetInterfaces();
+
+    private static string Ref(Type type) => "#/$defs/" + DefName(type);
+
+    private static string DefName(Type type) => JsonNamingPolicy.CamelCase.ConvertName(type.Name);
+}

--- a/tools/Bpmn.Schema.Generator/Program.cs
+++ b/tools/Bpmn.Schema.Generator/Program.cs
@@ -3,9 +3,12 @@ using Bpmn.Schema.Generator;
 
 // Writes the checked-in schema. The generated file is committed so a format change shows up as a
 // schema diff in review rather than as an invisible consequence of editing a model class.
-var repositoryRoot = args.Length > 0
-    ? args[0]
-    : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+//
+// The root is found by walking up to the solution file rather than by counting "..' segments out of
+// the build output, so the tool keeps working when the target framework or configuration changes the
+// depth of that path. A counted walk would not fail there - it would write a schema to the wrong place
+// and report success.
+var repositoryRoot = args.Length > 0 ? args[0] : FindRepositoryRoot();
 
 var destination = Path.Combine(repositoryRoot, "src", "Bpmn.Model", "schema", BpmnPayloadFormat.SchemaFileName);
 Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
@@ -18,3 +21,16 @@ File.WriteAllText(destination, schema);
 Console.WriteLine($"Payload format version : {BpmnPayloadFormat.Version}");
 Console.WriteLine($"Schema                 : {destination}");
 Console.WriteLine(unchanged ? "Result                 : unchanged" : "Result                 : WRITTEN (review the diff)");
+
+static string FindRepositoryRoot()
+{
+    var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+    while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Bpmn.slnx")))
+        directory = directory.Parent;
+
+    return directory?.FullName
+        ?? throw new InvalidOperationException(
+            "Could not locate the repository root (no Bpmn.slnx above the build output). "
+            + "Pass it explicitly: dotnet run --project tools/Bpmn.Schema.Generator -- <root>");
+}

--- a/tools/Bpmn.Schema.Generator/Program.cs
+++ b/tools/Bpmn.Schema.Generator/Program.cs
@@ -1,0 +1,20 @@
+using Bpmn.Model;
+using Bpmn.Schema.Generator;
+
+// Writes the checked-in schema. The generated file is committed so a format change shows up as a
+// schema diff in review rather than as an invisible consequence of editing a model class.
+var repositoryRoot = args.Length > 0
+    ? args[0]
+    : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+
+var destination = Path.Combine(repositoryRoot, "src", "Bpmn.Model", "schema", BpmnPayloadFormat.SchemaFileName);
+Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+
+var schema = BpmnSchemaGenerator.Generate();
+var unchanged = File.Exists(destination) && File.ReadAllText(destination) == schema;
+
+File.WriteAllText(destination, schema);
+
+Console.WriteLine($"Payload format version : {BpmnPayloadFormat.Version}");
+Console.WriteLine($"Schema                 : {destination}");
+Console.WriteLine(unchanged ? "Result                 : unchanged" : "Result                 : WRITTEN (review the diff)");


### PR DESCRIPTION
Closes #9.

ADR 0005 promised a versioned payload format with a published JSON Schema. The repository had neither: no schema file, no generator, and no version constant, while `.github/pull_request_template.md` asked authors to keep a version in step that had never existed. This ships both — and then fixes what shipping them exposed.

Two commits, deliberately separate:

1. **`2ed643a`** publishes the schema, the generator, the version constant, and the drift guard.
2. **`880a0bb`** normalizes the format defect that generating the schema uncovered, and freezes the format at `1.0.0`.

## What is here

- **`BpmnPayloadFormat`** carries `Version` and `SchemaId`. The format version is separate from the package version deliberately: the package moves for reasons that have nothing to do with the shape of a serialized document, so it is the wrong thing to pin to.
- **`tools/Bpmn.Schema.Generator`** derives the schema from the model by reflection. It never ships, and it has no `PackageReference` of its own, so the four packages' zero-dependency promise is untouched.
- **`src/Bpmn.Model/schema/bpmn-payload.schema.json`** is generated and checked in, so a format change shows up as a schema diff in review rather than as an invisible consequence of editing a model class. It is packed into `Bpmn.Model` under `schema/`, which is what makes "published as a build artifact" literally true.
- **`PayloadSchemaTests`** regenerates and compares on every test run, so the artifact cannot rot, and cross-checks the schema against real serializer output.

41 types are described. The format covers **two** documents, not one, and a schema's own `$ref` can only describe one of them: `bpmn-payload.schema.json` validates a definition, `bpmn-payload.schema.json#/$defs/bpmnExecutionState` validates the execution state of a running instance, and `x-roots` lists both so a code generator does not have to know those names.

## The generator describes the serializer, not the model

This is the part that mattered. A schema derived from what the C# types *look like* would have been wrong in three ways, each of which is a place a hand-written mirror drifts:

- **Enums are integers.** The model declares no `JsonStringEnumConverter` anywhere, so every enum crosses the wire as a number. The schema publishes names alongside as `x-enumNames` so a code generator can still emit a readable type.
- **Computed get-only properties are on the wire.** `System.Text.Json` serializes them, so they are part of the contract whether or not anyone intended that.
- **There is no naming policy.** With default options a property lacking `[JsonPropertyName]` is written under its CLR name verbatim.

The first draft assumed camelCase for that last one. Two cross-check tests failed immediately, which is the entire argument for having them.

## What publishing it exposed

**The format used two naming conventions.**

| | Convention | Why |
| --- | --- | --- |
| Definition side | camelCase | explicit `[JsonPropertyName]` throughout |
| All of `Bpmn.Model.State` | **PascalCase** | no attributes at all |
| `BpmnProcessDefinition.Extensions` | **PascalCase** | outlier, inconsistent with its own sibling in the same file |

53 properties followed the wrong one of two conventions in a single document. `BpmnDefinitions.Extensions` carries the attribute; `BpmnProcessDefinition.Extensions`, forty lines away, did not.

This is exactly the class of defect ADR 0005 predicted a hand-written mirror would introduce, and it was in the format itself the whole time. Nothing was checking, because nothing had ever written the format down. It is also precisely why the schema is worth generating rather than writing: the generator could not fail to notice.

## Why normalize now rather than defer it

The first commit published the inconsistency as-is at `0.1.0` and left the fix as a follow-up. The second commit does the fix instead, because the timing argument only points one way:

- The cost of normalizing is **bounded now** — the library is pre-1.0, and no schema had ever been published for a consumer to generate against.
- The cost is **unbounded later** — once consumers have generated types from a `1.0` contract, the same rename breaks every language at once, which is the exact failure ADR 0005 exists to prevent.

The one thing worse than a format with a wart is a format whose first published version enshrines it. So the names are normalized and the version is `1.0.0` rather than something below 1.0, to say that it is now frozen.

**Explicitness is enforced, not conventional.** Every serialized property declares its wire name, and `Model_declares_every_serialized_name` fails on any that does not — because the failure mode here was never a *wrong* name, it was a property nobody had named at all. The test checks the convention rather than a mechanical derivation, so a deliberate rename stays legal: `BpmnQName.Namespace` is published as `ns`, since the CLR name only reads that way because `namespace` is a keyword.

### ⚠️ Breaking change

Execution state persisted by `0.1.x` no longer deserializes. Nothing had shipped against a published schema, so there is nothing to migrate.

Note that the package version (`0.1.1`) and the format version (`1.0.0`) now move in opposite directions. That is the distinction `BpmnPayloadFormat` exists to make, but it is worth being explicit about in the release notes.

## Smaller fixes carried along

- **`Generate(out var covered)`** reports the generator's type closure, so tests assert over exactly what lands in `$defs` rather than a second hand-maintained list that can drift.
- **Repository-root discovery** walks up to `Bpmn.slnx` instead of counting five `..` segments out of the build output. A counted walk would not *fail* on a target-framework change — it would write the schema somewhere else and report success.
- **`tools/` is now scanned by both host-agnostic guards.** It is a new top-level source directory that neither the CI script nor `HostAgnosticBoundaryTests` covered.

## Verification

- `dotnet build Bpmn.slnx -c Release`: clean, 0 warnings.
- `dotnet test Bpmn.slnx -c Release`: **338 passed, 0 failed.**
- `python3 .github/scripts/check-host-agnostic.py .`: 142 files, no host-specific references.
- All four samples run clean under `--non-interactive`.
- `dotnet pack src/Bpmn.Model`: `schema/bpmn-payload.schema.json` present in the `.nupkg`.
- **Independently validated**: the schema is a valid draft 2020-12 document, and real `System.Text.Json` output for *both* roots validates against it under a third-party validator rather than only against this repository's own tests.
- **The drift guard was confirmed to fail**: tampering with the checked-in schema produces "The checked-in schema is stale" with the regeneration command, then passes again once restored.
