### PR TITLE
fix(semantics)!: tear down the work a cancelled transaction abandons

### DIFF
--- a/docs/concepts/capabilities.md
+++ b/docs/concepts/capabilities.md
@@ -163,6 +163,7 @@ day it does not.
 | Catch boundary event (timer, message, signal), even non-interrupting | `SubtreeCancellation` | Its armed listener is torn down when its host completes. |
 | Event subprocess | `SubtreeCancellation` | An interrupting one drains the scope; every scope listener is retired when the scope completes. |
 | Event-based gateway | `SubtreeCancellation` | The losing branches are torn down when the first catch wins. |
+| Cancel end event | `SubtreeCancellation` | It tears down the transaction's other live work when it abandons it. |
 | Escalation throw or end event, escalation boundary event | `ScopeSignalling` | A throw signals the enclosing scope, and a scope re-signals what it cannot match itself. |
 | Multi-instance activity | `IterationScopes` | Each instance needs its own frame. |
 | Collection-mode multi-instance | `ScopeVariables` | Its instance count and items come from a declared variable. |

--- a/docs/concepts/errors-and-escalation.md
+++ b/docs/concepts/errors-and-escalation.md
@@ -140,7 +140,8 @@ an element with `isTransaction: true` — and a cancel boundary event is valid o
 
 The sequence, when a cancel end event fires:
 
-1. All other live work in the transaction stops.
+1. All other live work in the transaction stops, and is torn down on the host — a cancelled
+   transaction leaves nothing running behind it.
 2. The transaction's registered compensations replay, in reverse order.
 3. The scope completes with the `Cancelled` outcome, which is distinct from ordinary completion.
 4. A cancel boundary event on the transaction, if present, routes the cancellation path in the parent.

--- a/docs/guides/hosting-the-interpreter.md
+++ b/docs/guides/hosting-the-interpreter.md
@@ -194,6 +194,13 @@ one binding ref and iteration id are indistinguishable to it, and completing eit
 other's token. Multi-instance is exactly why `IterationId` exists: instances share a binding ref and
 are told apart by it.
 
+Read that as holding **once you have applied a command batch in full, in order** — not at every point
+within one. An interrupting path may emit the replacement `StartWork` ahead of the
+`CancelWorkSubtree` for the unit it supersedes, so a host that stopped halfway through the batch
+would see the slot doubly occupied. That is why two other checklist items are load-bearing here:
+apply commands in the order returned, and key your ledger by handle rather than by slot, so the
+teardown still names the older unit unambiguously.
+
 One corollary, because it is an easy and damaging mistake: **do not put a completing unit of work's
 correlation into `InvocationCorrelation` to "help".** That dictionary is the scope's, fixed for the
 scope's lifetime, and the event-subprocess start-element hint is read from it. Overwriting it
@@ -460,7 +467,8 @@ command shape constrains when decisions are made, not when work happens.
 - [ ] Persist `evaluation.State.Prune()` before acting on commands, if you persist.
 - [ ] Apply commands in the order returned.
 - [ ] Report a callback with the same binding ref and handle the work was started under.
-- [ ] Keep at most one live unit of work per `(BindingRef, IterationId)` in a scope.
+- [ ] Keep at most one live unit of work per `(BindingRef, IterationId)` in a scope, once each
+      command batch has been applied in full. Key your ledger by handle, not by slot.
 - [ ] Pass `StartWork.Correlation` into a nested process as its `InvocationCorrelation`, and never
       write anything else into that dictionary.
 - [ ] Remove finished work from `LiveWork` **before** calling `OnWorkCompleted` or `OnWorkFaulted`,

--- a/docs/reference/supported-constructs.md
+++ b/docs/reference/supported-constructs.md
@@ -140,7 +140,7 @@ graph-build time.
 | Compensation registration | Supported | A successful completion of an activity carrying a compensation boundary is logged. |
 | Reverse-order replay | Supported | Last registered, first compensated. Entries are never pruned; a claimed entry whose run is torn down before it ran is released back to registered. |
 | Targeted compensation (`activityRef`) | Supported | Compensates only that element's registrations; absent means everything registered in the process. |
-| Transaction subprocess | Supported | Cancel from within stops other live work, replays compensations, and completes with the `Cancelled` outcome. A transaction that completes `Cancelled` with no cancel boundary attached raises a fault. |
+| Transaction subprocess | Supported | Cancel from within stops and tears down other live work, replays compensations, and completes with the `Cancelled` outcome. A transaction that completes `Cancelled` with no cancel boundary attached raises a fault. |
 
 ## Collaboration
 

--- a/src/Bpmn.Semantics/BpmnEvaluationContext.cs
+++ b/src/Bpmn.Semantics/BpmnEvaluationContext.cs
@@ -3,6 +3,14 @@ using Bpmn.Model.State;
 namespace Bpmn.Semantics;
 
 /// <summary>
+/// One running unit of work to tear down: a losing event-based-gateway branch, an interrupted boundary
+/// host, a retired listener, the work a cancelled transaction abandons. Carried — on the evaluation result,
+/// or on the evaluation context when the result cannot reach the caller — and issued only on a non-fault
+/// continuation.
+/// </summary>
+internal sealed record PendingTeardown(string Handle, string ElementId, string Reason);
+
+/// <summary>
 /// The mutable scratch space of one interpreter evaluation: the host snapshot it reads, and the command list
 /// it builds. It exists so the interpreter can stay a pure function of its request — nothing here reaches the
 /// host, and nothing here survives the evaluation.
@@ -10,6 +18,7 @@ namespace Bpmn.Semantics;
 internal sealed class BpmnEvaluationContext(BpmnHostSnapshot host)
 {
     private readonly List<BpmnHostCommand> _commands = [];
+    private readonly List<PendingTeardown> _carriedTeardowns = [];
 
     /// <summary>What the host told the interpreter about its world.</summary>
     public BpmnHostSnapshot Host { get; } = host;
@@ -37,4 +46,15 @@ internal sealed class BpmnEvaluationContext(BpmnHostSnapshot host)
     /// faults, because the whole scope is going away and a premature teardown would race the fault.
     /// </summary>
     public void AddCommand(BpmnHostCommand command) => _commands.Add(command);
+
+    /// <summary>
+    /// Teardowns discovered inside the token propagation loop, which the evaluation result cannot carry out:
+    /// the loop keeps only each step's state and returns a fresh result, so anything else a step carried is
+    /// dropped. They are held here instead, and issued under exactly the same rule as the result-carried ones
+    /// — at the clean exit only, never on a fault.
+    /// </summary>
+    public IReadOnlyList<PendingTeardown> CarriedTeardowns => _carriedTeardowns;
+
+    /// <summary>Carries a teardown to the clean exit, for a step whose result never reaches the caller.</summary>
+    public void CarryTeardown(PendingTeardown teardown) => _carriedTeardowns.Add(teardown);
 }

--- a/src/Bpmn.Semantics/BpmnHostCapabilities.cs
+++ b/src/Bpmn.Semantics/BpmnHostCapabilities.cs
@@ -78,8 +78,9 @@ public sealed record BpmnCapabilityRequirements(
     /// <item><b>Subtree cancellation</b> — every construct that tears running work down: an interrupting
     /// boundary event, a catch boundary event (whose armed listener is torn down when its host completes),
     /// an event subprocess (an interrupting one drains the whole scope; every scope listener is retired when
-    /// the scope completes), and an event-based gateway (whose losing branches are torn down when the first
-    /// catch wins).</item>
+    /// the scope completes), an event-based gateway (whose losing branches are torn down when the first
+    /// catch wins), and a cancel end event (which tears down the transaction's other live work when it
+    /// abandons it).</item>
     /// <item><b>Scope signalling</b> — escalation: a throw or end event signals the enclosing scope, and a
     /// scope carrying escalation catchers re-signals what it cannot match itself.</item>
     /// <item><b>Iteration scopes</b> — a multi-instance activity.</item>
@@ -115,6 +116,9 @@ public sealed record BpmnCapabilityRequirements(
                 Require(BpmnHostCapabilities.SubtreeCancellation, element.ElementId);
 
             if (StringComparer.Ordinal.Equals(element.ElementType, BpmnElementTypes.EventBasedGateway))
+                Require(BpmnHostCapabilities.SubtreeCancellation, element.ElementId);
+
+            if (BpmnElementFamilies.IsCancelEndEvent(element))
                 Require(BpmnHostCapabilities.SubtreeCancellation, element.ElementId);
 
             if (BpmnElementFamilies.IsEscalationThrowOrEnd(element) || BpmnElementFamilies.IsEscalationBoundary(element))

--- a/src/Bpmn.Semantics/BpmnHostContracts.cs
+++ b/src/Bpmn.Semantics/BpmnHostContracts.cs
@@ -32,6 +32,14 @@ namespace Bpmn.Semantics;
 /// work per (binding ref, iteration id) within a scope</b>. Multi-instance instances share a binding ref
 /// and are told apart by their iteration id, which is what it is for.
 /// </para>
+/// <para>
+/// The rule holds <b>once a command batch has been applied in full, in order</b> — not at every point
+/// within one. An interrupting path may emit the replacement <see cref="BpmnHostCommand.StartWork"/>
+/// ahead of the <see cref="BpmnHostCommand.CancelWorkSubtree"/> for the unit it supersedes, so a host
+/// that applied the batch halfway would see the slot doubly occupied. Two obligations follow: apply
+/// commands in the order returned, and key the ledger by handle rather than by slot, so the teardown
+/// still names the older unit unambiguously.
+/// </para>
 /// </param>
 /// <param name="Variables">The process's declared variables, as the host sees them.</param>
 /// <param name="Capabilities">What this host can do. Must match what the graph was built with.</param>

--- a/src/Bpmn.Semantics/BpmnInterpreter.cs
+++ b/src/Bpmn.Semantics/BpmnInterpreter.cs
@@ -134,9 +134,9 @@ public sealed class BpmnInterpreter
         [CallActivityFaultedOutcomeName, CallActivityDispatchFailedOutcomeName, CallActivityCancelledOutcomeName];
 
     /// <summary>
-    /// An empty live-work map. A cancel end event and an own-scope escalation activation stop other live work
-    /// logically only: work already running keeps running and its late completion is absorbed by the
-    /// cancelled-token guard, so no teardown command is issued.
+    /// An empty live-work map. An own-scope escalation activation stops other live work logically only: work
+    /// already running keeps running and its late completion is absorbed by the cancelled-token guard, so no
+    /// teardown command is issued.
     /// </summary>
     private static readonly IReadOnlyDictionary<(string BindingRef, string? IterationId), string> NoLiveWork =
         new Dictionary<(string BindingRef, string? IterationId), string>();
@@ -1421,6 +1421,11 @@ public sealed class BpmnInterpreter
     /// <summary>
     /// The result of one internal step. Faults, teardowns, and the outward signal are <b>carried</b> here and
     /// only turned into commands at the clean exit — see <see cref="FinishEvaluation"/>.
+    /// <para>
+    /// This is not the only teardown channel. A step inside the propagation loop returns a result the loop
+    /// discards but for its state, so it carries teardowns on <see cref="BpmnEvaluationContext"/> instead; both
+    /// drain in <see cref="IssueCarriedCommands"/> under the same non-fault rule.
+    /// </para>
     /// </summary>
     private sealed record EvaluationResult(
         BpmnExecutionState State,
@@ -1432,12 +1437,6 @@ public sealed class BpmnInterpreter
 
     /// <summary>A deterministic process failure, carried until the evaluation decides how to surface it.</summary>
     private sealed record BpmnFault(string Code, string Message);
-
-    /// <summary>
-    /// One running unit of work to tear down: a losing event-based-gateway branch, an interrupted boundary
-    /// host, a retired listener. Carried on the evaluation result and issued only on a non-fault continuation.
-    /// </summary>
-    private sealed record PendingTeardown(string Handle, string ElementId, string Reason);
 
     /// <summary>An escalation this scope could not match, to be re-signalled one hop outward. Issued only on a non-fault continuation.</summary>
     private sealed record PendingScopeSignal(string Code, JsonElement? Payload);
@@ -1617,7 +1616,7 @@ public sealed class BpmnInterpreter
 
         // Activate the own-scope event subprocess now that the throw's routing command has run. This evaluation
         // rides the propagation loop, so an interrupting activation stops other live work logically only
-        // (NoLiveWork); work already running is absorbed on late completion, as for a cancelled transaction.
+        // (NoLiveWork); work already running is absorbed on late completion by the cancelled-token guard.
         if (ownScopeActivation is { } catcher)
         {
             var ownScopeCancellations = new List<PendingTeardown>();
@@ -1722,14 +1721,21 @@ public sealed class BpmnInterpreter
 
     /// <summary>
     /// Handles a <c>CancelTransaction</c> command: a cancel end event fired inside a transaction
-    /// scope. First it stops all OTHER live work logically — every live token except the cancel-end token is
-    /// cancelled through <see cref="CancelTokenAndWork"/> so the multi-instance, race, and compensation-run
-    /// coordinator cascades tear loops, races, and replays down consistently — while work already running keeps
-    /// running and is absorbed on late completion (logical only, no teardown issued). It records the <c>Cancelling</c>
+    /// scope. First it stops all OTHER live work — every live token except the cancel-end token is cancelled
+    /// through <see cref="CancelTokenAndWork"/> so the multi-instance, race, and compensation-run coordinator
+    /// cascades tear loops, races, and replays down consistently — and the work behind those tokens is torn
+    /// down on the host, so an abandoned transaction leaves nothing running. It records the <c>Cancelling</c>
     /// verdict, then claims every <c>Registered</c> compensable (the whole scope) in reverse registration order and
     /// opens a <see cref="BpmnCompensationRun"/> coordinated by the cancel-end token, starting the first
     /// handler. An empty claim consumes the cancel-end token immediately; <see cref="FinishEvaluation"/> then
     /// completes the process with the <c>Cancelled</c> outcome once nothing is live.
+    /// <para>
+    /// Tearing the abandoned work down is what keeps the scope's slots honest. Stopping an in-flight
+    /// compensation run releases its unrun compensables, and the fresh run re-claims them and restarts its head
+    /// handler — the same element, under the same binding ref and inherited iteration key. Without the teardown
+    /// the host would hold two live units for that one slot, which is the one thing
+    /// <see cref="BpmnHostSnapshot"/> asks a host never to do and which it has no way to prevent by itself.
+    /// </para>
     /// </summary>
     private EvaluationResult CancelTransaction(
         BpmnEvaluationContext context,
@@ -1739,14 +1745,21 @@ public sealed class BpmnInterpreter
         BpmnElement cancelEndElement,
         string producedBy)
     {
-        // Step 1: stop all OTHER live work logically. The cancel-end token stays live as the coming replay's
-        // coordinator; every other live token is cancelled, cascading loop, race, and compensation-run teardown.
-        // Work already running keeps running (empty live-work map, so no teardown is issued) and is absorbed on
-        // late completion. The stop-others loop is shared with an interrupting event-subprocess activation.
-        var stopScratch = new List<PendingTeardown>();
-        var (stoppedState, stoppedCount) = StopOtherLiveWork(state, cancelEndToken.TokenId, TransactionCancelledStopReason, NoLiveWork, stopScratch,
+        // Step 1: stop all OTHER live work. The cancel-end token stays live as the coming replay's coordinator;
+        // every other live token is cancelled, cascading loop, race, and compensation-run teardown, and the work
+        // behind it is torn down on the host. The teardown is not optional here: step 2 re-claims the compensables
+        // an in-flight run just released and restarts its head handler on the same (binding ref, iteration id)
+        // slot, so leaving the old unit live would put two of them in one slot. The stop-others loop is shared
+        // with an interrupting event-subprocess activation.
+        var pendingCancellations = new List<PendingTeardown>();
+        var (stoppedState, stoppedCount) = StopOtherLiveWork(state, cancelEndToken.TokenId, TransactionCancelledStopReason, BuildLiveWorkHandles(context), pendingCancellations,
             (token, reason) => $"BPMN cancel end event '{cancelEndElement.ElementId}' stopped live token '{token.TokenId}' at '{token.AtElementId}' ({reason}).");
         state = stoppedState;
+
+        // A cancel end event is reached by a token arriving, so this runs inside the propagation loop, whose
+        // result never reaches the caller intact. The teardowns ride the context to the clean exit instead.
+        foreach (var teardown in pendingCancellations)
+            context.CarryTeardown(teardown);
 
         state = state with { Cancelling = true, Sequence = state.Sequence + 1 };
         state = BpmnDiagnosticAccumulator.Add(state, BpmnDiagnosticKind.TransactionCancelled, cancelEndElement.ElementId, null, cancelEndToken.TokenId,
@@ -2201,9 +2214,10 @@ public sealed class BpmnInterpreter
     /// Stops all live work in the scope except <paramref name="keepTokenId"/>: every other
     /// live token is cancelled through <see cref="CancelTokenAndWork"/> so the multi-instance, race, and
     /// compensation-run coordinator cascades tear loops, races, and replays down consistently. Shared by the
-    /// cancel-transaction path (which keeps the cancel-end coordinator, logical only via
-    /// <see cref="NoLiveWork"/>) and by an interrupting event-subprocess activation (which keeps the activation
-    /// token). Returns the count of stopped tokens for the caller's diagnostic.
+    /// cancel-transaction path (which keeps the cancel-end coordinator) and by an interrupting event-subprocess
+    /// activation (which keeps the activation token). Whether the stopped work is torn down on the host or only
+    /// dropped logically is the caller's call, made by what it passes as <paramref name="liveWorkHandles"/>.
+    /// Returns the count of stopped tokens for the caller's diagnostic.
     /// </summary>
     private static (BpmnExecutionState State, int StoppedCount) StopOtherLiveWork(
         BpmnExecutionState state,
@@ -2288,10 +2302,15 @@ public sealed class BpmnInterpreter
         return liveWorkHandles;
     }
 
-    /// <summary>Issues each carried teardown and the re-signalled escalation, if any. Only called from a non-fault continuation.</summary>
+    /// <summary>
+    /// Issues each carried teardown and the re-signalled escalation, if any. Only called from a non-fault
+    /// continuation. Teardowns arrive on two channels — the result, for a step whose result reaches the caller,
+    /// and the context, for one inside the propagation loop whose result does not — and both drain here, so the
+    /// non-fault rule holds for either.
+    /// </summary>
     private static void IssueCarriedCommands(BpmnEvaluationContext context, EvaluationResult result)
     {
-        foreach (var teardown in result.PendingTeardowns ?? [])
+        foreach (var teardown in (result.PendingTeardowns ?? []).Concat(context.CarriedTeardowns))
             context.AddCommand(new BpmnHostCommand.CancelWorkSubtree(teardown.Handle, teardown.ElementId, teardown.Reason));
 
         if (result.PendingScopeSignal is { } signal)

--- a/tests/Bpmn.Semantics.Tests/ProcessFixtures.cs
+++ b/tests/Bpmn.Semantics.Tests/ProcessFixtures.cs
@@ -234,6 +234,89 @@ public static class ProcessFixtures
             .Connect("Join", "End")
             .Build();
 
+    /// <summary>
+    /// A transaction subprocess that cancels itself while a compensation replay is already in flight, which is
+    /// the shape that puts two units of work on one slot: stopping the in-flight run releases its unrun
+    /// compensable, and the cancel's own run then re-claims it and restarts the same handler.
+    /// <para>
+    /// The body splits in two (three with <paramref name="withThirdBranch"/>): one branch reserves and then
+    /// throws a compensate event, parking on the replay; another completes a task and hits the cancel end event.
+    /// The third branch, when present, is work that is still genuinely in flight and has nothing to do with the
+    /// slot collision — it is what separates tearing down everything from tearing down only the re-used slot.
+    /// </para>
+    /// </summary>
+    public static (BpmnProcessDefinition Parent, BpmnProcessDefinition Body) CancellableTransaction(bool withThirdBranch = false)
+    {
+        var body = new BpmnProcessBuilder("booking")
+            .Transaction()
+            .StartEvent("BodyStart")
+            .ParallelGateway("Split")
+            .Task("Reserve", bindingRef: "reserve")
+            .IntermediateThrowEvent("Replay", new BpmnEventDefinition(BpmnEventDefinitionTypes.Compensation))
+            .EndEvent("EndReserved")
+            .Task("Trigger", bindingRef: "trigger")
+            .EndEvent("CancelEnd", null, new BpmnEventDefinition(BpmnEventDefinitionTypes.Cancel))
+            .Connect("BodyStart", "Split")
+            .Connect("Split", "Reserve")
+            .ConnectSequence("Reserve", "Replay", "EndReserved")
+            .Connect("Split", "Trigger")
+            .ConnectSequence("Trigger", "CancelEnd");
+
+        CompensateReserve(body);
+
+        if (withThirdBranch)
+            body.Task("Audit", bindingRef: "audit")
+                .EndEvent("EndAudited")
+                .Connect("Split", "Audit")
+                .ConnectSequence("Audit", "EndAudited");
+
+        return (CancellableTransactionParent(), body.Build());
+    }
+
+    /// <summary>
+    /// The same transaction cancelling with nothing else live: one sequential branch, so when the cancel end
+    /// event fires the only work the scope starts is the compensation the cancel itself replays.
+    /// </summary>
+    public static (BpmnProcessDefinition Parent, BpmnProcessDefinition Body) CancellableTransactionWithNothingElseLive()
+    {
+        var body = new BpmnProcessBuilder("booking")
+            .Transaction()
+            .StartEvent("BodyStart")
+            .Task("Reserve", bindingRef: "reserve")
+            .Task("Trigger", bindingRef: "trigger")
+            .EndEvent("CancelEnd", null, new BpmnEventDefinition(BpmnEventDefinitionTypes.Cancel))
+            .ConnectSequence("BodyStart", "Reserve", "Trigger", "CancelEnd");
+
+        CompensateReserve(body);
+
+        return (CancellableTransactionParent(), body.Build());
+    }
+
+    /// <summary>Registers <c>Reserve</c> for compensation by <c>UndoReserve</c>: the boundary event and the handler it names.</summary>
+    private static void CompensateReserve(BpmnProcessBuilder body) =>
+        body.Element(new BpmnElement(
+                "ReserveCompensation", BpmnElementTypes.BoundaryEvent,
+                attachedToRef: "Reserve",
+                compensationHandlerElementId: "UndoReserve",
+                eventDefinitions: [new BpmnEventDefinition(BpmnEventDefinitionTypes.Compensation)]))
+            .Element(new BpmnElement(
+                "UndoReserve", BpmnElementTypes.Task,
+                bindingRef: "undo-reserve",
+                isForCompensation: true));
+
+    /// <summary>The enclosing scope for a cancellable transaction: a cancel boundary routes the cancellation to recovery.</summary>
+    private static BpmnProcessDefinition CancellableTransactionParent() =>
+        new BpmnProcessBuilder("parent")
+            .StartEvent("Start")
+            .SubProcess("Booking", bindingRef: "booking", isTransaction: true)
+            .EndEvent("EndDone")
+            .BoundaryEvent("BookingCancelled", "Booking", new BpmnEventDefinition(BpmnEventDefinitionTypes.Cancel))
+            .Task("Recover", bindingRef: "recover")
+            .EndEvent("EndCancelled")
+            .ConnectSequence("Start", "Booking", "EndDone")
+            .ConnectSequence("BookingCancelled", "Recover", "EndCancelled")
+            .Build();
+
     public static BpmnEventDefinition Timer(string isoDuration) =>
         new(BpmnEventDefinitionTypes.Timer,
             new Dictionary<string, string>(StringComparer.Ordinal) { [BpmnEventDefinitionProperties.Interval] = isoDuration });

--- a/tests/Bpmn.Semantics.Tests/TransactionCancellationTests.cs
+++ b/tests/Bpmn.Semantics.Tests/TransactionCancellationTests.cs
@@ -1,0 +1,118 @@
+using Bpmn.Model;
+using Bpmn.Runtime.InMemory;
+using Shouldly;
+using Xunit;
+
+namespace Bpmn.Semantics.Tests;
+
+/// <summary>
+/// A cancel end event abandoning a transaction, watched from the host's side of the port.
+/// <para>
+/// The interesting case is cancelling while a compensation replay is in flight. Stopping the in-flight run
+/// releases its unrun compensable, and the cancel's own run re-claims it and restarts the same handler — the
+/// same element, so the same binding ref and the same inherited iteration key. Unless the abandoned unit is
+/// torn down, the host is left holding two live units for one slot, which is the one thing
+/// <see cref="BpmnHostSnapshot"/> asks it never to do and the one thing it cannot prevent by itself: its
+/// ledger has exactly two inputs, and both of them are interpreter commands.
+/// </para>
+/// </summary>
+public sealed class TransactionCancellationTests
+{
+    private static (InMemoryProcessInstance Parent, InMemoryProcessInstance Transaction) StartTransaction(
+        (BpmnProcessDefinition Parent, BpmnProcessDefinition Body) fixture)
+    {
+        var host = new InMemoryBpmnHost(new InMemoryBpmnHostOptions
+        {
+            NestedProcesses = new Dictionary<string, BpmnProcessDefinition>(StringComparer.Ordinal) { ["booking"] = fixture.Body }
+        });
+
+        var parent = host.Start(fixture.Parent);
+        return (parent, parent.Children.ShouldHaveSingleItem());
+    }
+
+    /// <summary>Drives the transaction to the moment of cancellation and reports the handle of the compensation handler left mid-replay.</summary>
+    private static string CancelMidReplay(InMemoryProcessInstance transaction)
+    {
+        transaction.CompleteWork("reserve");
+        var replaying = transaction.ResolveWork("undo-reserve");
+
+        transaction.CompleteWork("trigger");
+        return replaying.Handle;
+    }
+
+    private static IReadOnlyList<string> BindingRefs(InMemoryProcessInstance instance) =>
+        instance.PendingWork.Select(work => work.BindingRef).ToArray();
+
+    // --- The slot the cancel re-uses -------------------------------------------------------------------
+
+    [Fact]
+    public void Cancelling_mid_replay_tears_the_abandoned_handler_down_before_restarting_its_slot()
+    {
+        var (_, transaction) = StartTransaction(ProcessFixtures.CancellableTransaction());
+
+        var abandoned = CancelMidReplay(transaction);
+
+        BindingRefs(transaction).ShouldBe(["undo-reserve"], transaction.Transcript.ToString());
+        transaction.PendingWork.Single().Handle.ShouldNotBe(abandoned, "the cancel's run restarts the handler under a fresh handle");
+
+        var teardown = transaction.CancelledWork.ShouldHaveSingleItem(transaction.Transcript.ToString());
+        teardown.Handle.ShouldBe(abandoned, "the teardown must name the unit the host is still holding, not the replacement");
+        teardown.ElementId.ShouldBe("UndoReserve");
+        teardown.Reason.ShouldBe(BpmnInterpreter.TransactionCancelledStopReason);
+    }
+
+    [Fact]
+    public void Cancelling_tears_down_a_third_branch_that_is_still_genuinely_in_flight()
+    {
+        var (_, transaction) = StartTransaction(ProcessFixtures.CancellableTransaction(withThirdBranch: true));
+
+        var audit = transaction.ResolveWork("audit").Handle;
+        var abandoned = CancelMidReplay(transaction);
+
+        transaction.CancelledWork.Select(cancelled => cancelled.Handle)
+            .ShouldBe([abandoned, audit], ignoreOrder: true, customMessage: transaction.Transcript.ToString());
+        BindingRefs(transaction).ShouldBe(["undo-reserve"], "the abandoned transaction leaves nothing running but its own replay");
+    }
+
+    [Fact]
+    public void Cancelling_with_nothing_else_live_tears_nothing_down()
+    {
+        var (_, transaction) = StartTransaction(ProcessFixtures.CancellableTransactionWithNothingElseLive());
+
+        transaction.CompleteWork("reserve");
+        transaction.CompleteWork("trigger");
+
+        transaction.CancelledWork.ShouldBeEmpty(transaction.Transcript.ToString());
+        BindingRefs(transaction).ShouldBe(["undo-reserve"]);
+    }
+
+    // --- The path the teardowns run on -----------------------------------------------------------------
+
+    [Fact]
+    public void A_cancelled_transaction_finishes_its_replay_and_routes_the_parent_cancel_boundary()
+    {
+        var (parent, transaction) = StartTransaction(ProcessFixtures.CancellableTransaction());
+        CancelMidReplay(transaction);
+
+        transaction.CompleteWork("undo-reserve");
+
+        transaction.Outcome.ShouldBe(BpmnInterpreter.CancelledOutcomeName, transaction.Transcript.ToString());
+        parent.PendingWork.Select(work => work.ElementId).ShouldBe(["Recover"], parent.Transcript.ToString());
+
+        parent.CompleteWork("recover");
+        parent.IsCompleted.ShouldBeTrue(parent.Transcript.ToString());
+    }
+
+    // --- Capabilities ----------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_cancel_end_event_declares_the_subtree_cancellation_it_now_uses()
+    {
+        var (_, body) = ProcessFixtures.CancellableTransaction();
+
+        var requirements = BpmnCapabilityRequirements.Analyze(body);
+
+        requirements.MissingFrom(BpmnHostCapabilities.None).ShouldBe(BpmnHostCapabilities.SubtreeCancellation);
+        requirements.DrivingElementIds[BpmnHostCapabilities.SubtreeCancellation].ShouldBe(["CancelEnd"]);
+    }
+}


### PR DESCRIPTION
## What

`CancelTransaction` now passes real live-work handles instead of `NoLiveWork`, so the work a cancelled transaction abandons receives a real `CancelWorkSubtree` rather than being left running on the host. A cancel end event consequently declares the `SubtreeCancellation` capability, and the docs that described the old behaviour have been rewritten rather than left to contradict the code.

## Why

Closes #13.

`CancelTokenAndWork` only carries a teardown when the live-work lookup hits. Against a permanently empty map that lookup can never hit, so `ActiveWork` was dropped and nothing was issued. The sharp edge is not the leak but the slot collision: the same call tears down an in-flight compensation run and releases its `Claimed` compensables, and step 2 then re-claims them and restarts the head handler — the same element, so the same binding ref and inherited iteration key. The interpreter started a second unit on a slot the host still held.

`BuildLiveWorkHandles` keys by slot and overwrites, so with two live entries the surviving handle is whichever the host enumerated last, and a later teardown aimed at that slot can cancel the wrong execution. A host cannot defend against this — its ledger has exactly two inputs and both are our commands.

**Passing real handles was necessary and not sufficient.** Two further problems sat behind it, neither visible from the decompiled assembly the issue was filed against:

- `stopScratch` was a throwaway — never returned on the `EvaluationResult`, so a populated list would still have reached no host.
- Fixing that alone still emitted nothing. A cancel end event is reached by a token arriving, so `CancelTransaction` runs inside `Propagate`'s loop, which keeps only each step's state and returns a fresh result; `OnWorkCompleted` then overwrites `PendingTeardowns` outright. The result record is structurally incapable of carrying a teardown out of the propagation loop.

Teardowns discovered mid-propagation therefore ride `BpmnEvaluationContext`, which survives the evaluation. Both channels drain in `IssueCarriedCommands`, so the never-on-a-fault rule holds for either.

### Why the wide shape

The issue left the choice open between tearing down everything and tearing down only the re-used slot. Wide, because `docs/concepts/errors-and-escalation.md` already told users all other live work in the transaction stops, and because work that never completes on its own — a user task, a message subscription — leaks on the host indefinitely once the transaction is abandoned, since the absorbed-on-late-completion path never arrives.

### One ordering fact, now stated

`StartWork` appends inline during evaluation while teardowns become commands at `FinishEvaluation`, so the fresh compensation `StartWork` is emitted *before* the `CancelWorkSubtree` it replaces:

```
StartWork undo-reserve @UndoReserve token=token:47 cause=compensation; CancelWorkSubtree work-4 @UndoReserve (bpmn.transaction.cancel-stopped-live-work)
```

That is safe for a handle-keyed host applying commands in order, but it means the slot invariant holds at batch boundaries rather than continuously — and `BpmnHostSnapshot` stated it unqualified, so a host implementer would reasonably have assumed the stronger version. Reworded there and in the hosting guide.

### Breaking

A definition containing a cancel end event now requires `SubtreeCancellation` and is refused at graph-build time without it (ADR 0004). A cancelled transaction's other live work now receives a real `CancelWorkSubtree`, which a host observes.

## Checklist

- [x] `dotnet test Bpmn.slnx` passes — 343 tests, 5 new. Both TFMs build with 0 warnings; all four samples exit 0 under `--non-interactive`; the host-agnostic guard passes.
- [x] No host-specific references introduced
- [x] Public API changes are reflected in `docs/` — capabilities table, hosting guide, errors-and-escalation, supported-constructs
- [x] A behavior change to the interpreter has a test that fails without it — verified by reverting the one-line handle change: three of the five new tests fail, and pass again restored
- [x] On-disk format unchanged, so no schema or `BpmnPayloadFormat.Version` bump

Transaction cancellation and compensation had **no test coverage at all** before this. The new `TransactionCancellationTests` covers the mid-replay slot re-use, a third branch genuinely in flight (the case that separates this shape from the narrow one), a cancel with nothing else live, the end-to-end path through the parent cancel boundary, and the capability requirement.

## BPMN conformance

Untouched — this changes neither the reader nor the writer. The MIWG corpus results are unchanged (86 passing).

## Follow-up, not in this PR

`ApplyDecision`'s own-scope escalation activation has the same discarded-teardown shape. It cannot hit this wrong-handle hazard — the event-subprocess body binds its own `bindingRef` and cannot collide with a drained unit's slot — but the indefinite-leak argument does apply. Only its stale cross-reference to the cancelled transaction was corrected here; worth its own issue.

## Downstream

The Elsa host is deliberately unpatched so this stays visible there. On release, bump the `Bpmn.Semantics` pin in `elsa-core`'s `Directory.Packages.props` and flip `BpmnCompensationTests.CompensationRunCancelledMidReplay` to a single-record assertion. Because this is the wide shape, the teardown also reaches other-branch work, so that test may shift by more than the `releaseSeat` count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
