### PR TITLE
fix(semantics): tear down the work an own-scope escalation abandons

### DIFF
--- a/src/Bpmn.Semantics/BpmnInterpreter.cs
+++ b/src/Bpmn.Semantics/BpmnInterpreter.cs
@@ -134,9 +134,9 @@ public sealed class BpmnInterpreter
         [CallActivityFaultedOutcomeName, CallActivityDispatchFailedOutcomeName, CallActivityCancelledOutcomeName];
 
     /// <summary>
-    /// An empty live-work map. An own-scope escalation activation stops other live work logically only: work
-    /// already running keeps running and its late completion is absorbed by the cancelled-token guard, so no
-    /// teardown command is issued.
+    /// An empty live-work map, for a path that stops nothing: a non-interrupting escalation catcher leaves the
+    /// scope's other work alone, so it has no handles to resolve and issues no teardown. Every interrupting path
+    /// passes real handles — see <see cref="BuildLiveWorkHandles"/>.
     /// </summary>
     private static readonly IReadOnlyDictionary<(string BindingRef, string? IterationId), string> NoLiveWork =
         new Dictionary<(string BindingRef, string? IterationId), string>();
@@ -728,10 +728,12 @@ public sealed class BpmnInterpreter
     /// element (<c>AwaitingChild</c>, <c>ParentTokenId</c> null, inheriting <paramref name="triggerIterationKey"/>
     /// where one exists), and starts the bound body work seeded at its single event-start element via the
     /// start-element hint. An interrupting activation first stops all OTHER live work in the scope through the
-    /// shared <see cref="StopOtherLiveWork"/> helper (coordinator cascades and carried teardowns honored per the
-    /// caller's live-work map), keeping the activation token alive so the scope survives until the body completes. Non-
-    /// interrupting activations leave other scope work untouched: repeated or concurrent activations are
-    /// independent, each with its own token and its own body. Does not propagate; the caller drives that.
+    /// shared <see cref="StopOtherLiveWork"/> helper, which cascades coordinators and collects a teardown for
+    /// each stopped unit into <paramref name="pendingCancellations"/>, keeping the activation token alive so the
+    /// scope survives until the body completes. Non-interrupting activations leave other scope work untouched:
+    /// repeated or concurrent activations are independent, each with its own token and its own body. Does not
+    /// propagate, and does not deliver the teardowns it collected; the caller drives both, and which teardown
+    /// channel reaches the clean exit depends on where the caller sits — see <see cref="EvaluationResult"/>.
     /// </summary>
     private EvaluationResult ActivateEventSubprocess(
         BpmnEvaluationContext context,
@@ -1614,14 +1616,23 @@ public sealed class BpmnInterpreter
             }
         }
 
-        // Activate the own-scope event subprocess now that the throw's routing command has run. This evaluation
-        // rides the propagation loop, so an interrupting activation stops other live work logically only
-        // (NoLiveWork); work already running is absorbed on late completion by the cancelled-token guard.
+        // Activate the own-scope event subprocess now that the throw's routing command has run. An interrupting
+        // activation stops all OTHER live work in the scope and tears it down on the host: the interruption is
+        // real, and work nothing will ever complete on its own — a human task, a message subscription — would
+        // otherwise be held by the host for the rest of the scope's life.
         if (ownScopeActivation is { } catcher)
         {
             var ownScopeCancellations = new List<PendingTeardown>();
-            return ActivateEventSubprocess(context, graph, state, catcher, token.IterationKey, NoLiveWork, ownScopeCancellations,
-                producedBy, $"own-scope escalation code '{ReadEscalation(element).Code}'");
+            var activation = ActivateEventSubprocess(context, graph, state, catcher, token.IterationKey, BuildLiveWorkHandles(context),
+                ownScopeCancellations, producedBy, $"own-scope escalation code '{ReadEscalation(element).Code}'");
+
+            // This evaluation rides the propagation loop, whose result never reaches the caller intact, so the
+            // teardowns travel on the context instead. Cleared from the result so exactly one channel carries
+            // them however this activation's result is consumed.
+            foreach (var teardown in ownScopeCancellations)
+                context.CarryTeardown(teardown);
+
+            return activation with { PendingTeardowns = null };
         }
 
         return new EvaluationResult(state);

--- a/tests/Bpmn.Semantics.Tests/OwnScopeEscalationTests.cs
+++ b/tests/Bpmn.Semantics.Tests/OwnScopeEscalationTests.cs
@@ -1,0 +1,73 @@
+using Bpmn.Model;
+using Bpmn.Runtime.InMemory;
+using Shouldly;
+using Xunit;
+
+namespace Bpmn.Semantics.Tests;
+
+/// <summary>
+/// An escalation throw activating an interrupting event subprocess in its own scope, watched from the host's
+/// side of the port.
+/// <para>
+/// This activation drains the scope the same way an interrupting boundary event does, so the work it abandons
+/// has to be torn down: nothing else will ever complete a human task or a message subscription whose scope has
+/// just been interrupted, and a host that is never told holds it for the rest of the scope's life.
+/// </para>
+/// </summary>
+public sealed class OwnScopeEscalationTests
+{
+    private readonly InMemoryBpmnHost _host;
+    private readonly InMemoryProcessInstance _instance;
+
+    public OwnScopeEscalationTests()
+    {
+        var (parent, body) = ProcessFixtures.OwnScopeEscalationInterruptsASecondBranch();
+        _host = new InMemoryBpmnHost(new InMemoryBpmnHostOptions
+        {
+            NestedProcesses = new Dictionary<string, BpmnProcessDefinition>(StringComparer.Ordinal) { ["on-overdue"] = body }
+        });
+        _instance = _host.Start(parent);
+    }
+
+    private static IReadOnlyList<string> BindingRefs(InMemoryProcessInstance instance) =>
+        instance.PendingWork.Select(work => work.BindingRef).ToArray();
+
+    [Fact]
+    public void An_interrupting_own_scope_activation_tears_down_the_branch_it_abandons()
+    {
+        var abandoned = _instance.ResolveWork("long-running").Handle;
+
+        _instance.CompleteWork("escalate-trigger");
+
+        var teardown = _instance.CancelledWork.ShouldHaveSingleItem(_instance.Transcript.ToString());
+        teardown.Handle.ShouldBe(abandoned);
+        teardown.ElementId.ShouldBe("LongRunning");
+        BindingRefs(_instance).ShouldBe(["on-overdue"], "the interrupted scope runs the event subprocess body and nothing else");
+    }
+
+    [Fact]
+    public void The_event_subprocess_body_still_runs_to_completion_after_the_teardown()
+    {
+        _instance.CompleteWork("escalate-trigger");
+
+        var handler = _instance.Children.ShouldHaveSingleItem();
+        BindingRefs(handler).ShouldBe(["handle"]);
+
+        handler.CompleteWork("handle");
+
+        _instance.IsCompleted.ShouldBeTrue(_instance.Transcript.ToString());
+        _instance.Outcome.ShouldBe(BpmnInterpreter.DoneOutcomeName);
+    }
+
+    [Fact]
+    public void The_scope_declares_the_subtree_cancellation_its_activation_uses()
+    {
+        var (parent, _) = ProcessFixtures.OwnScopeEscalationInterruptsASecondBranch();
+
+        var requirements = BpmnCapabilityRequirements.Analyze(parent);
+
+        requirements.Required.HasFlag(BpmnHostCapabilities.SubtreeCancellation)
+            .ShouldBeTrue("the event subprocess element already drives the capability its activation needs");
+        requirements.DrivingElementIds[BpmnHostCapabilities.SubtreeCancellation].ShouldContain("OnOverdue");
+    }
+}

--- a/tests/Bpmn.Semantics.Tests/ProcessFixtures.cs
+++ b/tests/Bpmn.Semantics.Tests/ProcessFixtures.cs
@@ -317,6 +317,40 @@ public static class ProcessFixtures
             .ConnectSequence("BookingCancelled", "Recover", "EndCancelled")
             .Build();
 
+    /// <summary>
+    /// A scope that escalates to its own interrupting event subprocess while a second branch is still working.
+    /// The throw sits behind a task so the escalation fires only once the other branch's work is genuinely live.
+    /// The activation drains the scope, so the branch's task is abandoned mid-flight and must be torn down on
+    /// the host: nothing will ever complete it, and the scope that started it is being interrupted.
+    /// </summary>
+    public static (BpmnProcessDefinition Parent, BpmnProcessDefinition Body) OwnScopeEscalationInterruptsASecondBranch(string code = "overdue")
+    {
+        var body = new BpmnProcessBuilder("on-overdue")
+            .StartEvent("HandlerStart", null, Escalation(code))
+            .Task("Handle", bindingRef: "handle")
+            .EndEvent("HandlerEnd")
+            .ConnectSequence("HandlerStart", "Handle", "HandlerEnd")
+            .Build();
+
+        var parent = new BpmnProcessBuilder("escalating-scope")
+            .StartEvent("Start")
+            .ParallelGateway("Split")
+            .Task("Trigger", bindingRef: "escalate-trigger")
+            .IntermediateThrowEvent("Escalate", Escalation(code))
+            .EndEvent("EndEscalated")
+            .Task("LongRunning", bindingRef: "long-running")
+            .EndEvent("EndWorked")
+            .SubProcess("OnOverdue", bindingRef: "on-overdue", triggeredByEvent: true)
+            .Connect("Start", "Split")
+            .Connect("Split", "Trigger")
+            .ConnectSequence("Trigger", "Escalate", "EndEscalated")
+            .Connect("Split", "LongRunning")
+            .ConnectSequence("LongRunning", "EndWorked")
+            .Build();
+
+        return (parent, body);
+    }
+
     public static BpmnEventDefinition Timer(string isoDuration) =>
         new(BpmnEventDefinitionTypes.Timer,
             new Dictionary<string, string>(StringComparer.Ordinal) { [BpmnEventDefinitionProperties.Interval] = isoDuration });


### PR DESCRIPTION
## What

The own-scope escalation activation now passes real live-work handles and delivers the resulting teardowns, so an interrupting activation tears down the work it abandons instead of leaving it running on the host. This was the last `NoLiveWork` drain.

## Why

Closes #15. Follow-up to #13 / #14, which deliberately left this path alone rather than widening their own scope.

An interrupting `ActivateEventSubprocess` calls `StopOtherLiveWork`, which cancels every other live token in the scope and drops its `ActiveWork` record. Passed `NoLiveWork`, the lookup in `CancelTokenAndWork` could never hit, so no teardown was carried and the host kept every one of those units running. The comment justified that as absorbed on late completion — true for work that completes on its own, false for work that does not. Nothing completes a human task or a message subscription whose scope has just been interrupted.

### Why this is not a one-line change

`ActivateEventSubprocess` returns its teardowns on the result, but this call site returns into `ApplyDecision`'s caller — which on this path is `Propagate`'s loop, and that loop keeps only `result.State`. Swapping `NoLiveWork` for `BuildLiveWorkHandles(context)` alone therefore changes **nothing observable**.

That is the trap #15 flagged, and I verified it rather than trusting the analysis. With the argument swapped but the teardowns still on the result channel, `An_interrupting_own_scope_activation_tears_down_the_branch_it_abandons` still fails; it passes only once they travel on the context. So the teardowns take the channel #14 added for exactly this case — `BpmnEvaluationContext.CarryTeardown`, drained by `IssueCarriedCommands` under the same non-fault rule.

The result's copy is cleared at the call site, so one channel carries them however this activation's result is consumed, rather than leaving that a question a reader has to trace three frames to answer.

### What did not change, and why

**No capability change.** #15 flagged this as worth confirming rather than assuming. An own-scope activation requires an event subprocess in the same definition, and a `TriggeredByEvent` element already drives `SubtreeCancellation` — so the scope has always declared what this now uses. There is a test asserting it rather than a comment claiming it.

**No prose docs.** `capabilities.md` already said an interrupting event subprocess drains the scope; this makes that literally true rather than only logically true. I grepped for stale claims about work being left running and found none on this path.

**No wrong-handle hazard.** #15 was careful not to overstate this and I did not find one either: the body binds `catcher.BindingRef`, a binding ref is bound by exactly one element, and a second own-scope throw cannot reach the code because the first interrupting activation already cancelled every token that could carry one there. This is a leak fix, not a #13-shaped correctness fix.

The `NoLiveWork` doc is rewritten a second time. It now has exactly one caller — a non-interrupting escalation catcher, a path that genuinely stops nothing — so the empty map is finally what its name says rather than a decision in disguise.

## Checklist

- [x] `dotnet test Bpmn.slnx` passes — 346 tests, 3 new. Both TFMs build with 0 warnings; all four samples exit 0; host-agnostic guard passes.
- [x] No host-specific references introduced
- [x] Public API changes are reflected in `docs/` — none needed, see above
- [x] A behavior change to the interpreter has a test that fails without it — and one that fails against the naive one-line fix too
- [x] On-disk format unchanged

## BPMN conformance

Untouched — neither reader nor writer. MIWG corpus unchanged (86 passing).
