### PR TITLE
release: 0.2.0, and the interpreter half goes stable

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -86,25 +86,17 @@ jobs:
           set -euo pipefail
           mkdir -p ./artifacts
 
-          # Preview builds publish everything; a tagged release publishes only what is ready to be
-          # stable. Bpmn.Semantics and Bpmn.Runtime.InMemory ship at 0.2.0, once a second host has
-          # validated the interpreter's port - see docs/adr/0002. Publishing them to nuget.org now
-          # would turn every fix to that port into a breaking change against a public surface.
-          if [ "${{ github.event_name }}" = "release" ]; then
-            projects=(
-              "src/Bpmn.Model/Bpmn.Model.csproj"
-              "src/Bpmn.Interchange/Bpmn.Interchange.csproj"
-            )
-            echo "Release: packing the interchange half only."
-          else
-            projects=(
-              "src/Bpmn.Model/Bpmn.Model.csproj"
-              "src/Bpmn.Interchange/Bpmn.Interchange.csproj"
-              "src/Bpmn.Semantics/Bpmn.Semantics.csproj"
-              "src/Bpmn.Runtime.InMemory/Bpmn.Runtime.InMemory.csproj"
-            )
-            echo "Preview: packing all four."
-          fi
+          # All four ship together from 0.2.0. Bpmn.Semantics and Bpmn.Runtime.InMemory were held back
+          # through 0.1.x until a second host had validated the interpreter's port - see docs/adr/0002.
+          # One has now done so, and found real defects in it rather than merely compiling against it,
+          # which is the evidence the hold-back was waiting for. From here a fix to that port IS a
+          # change against a public surface, and is versioned accordingly.
+          projects=(
+            "src/Bpmn.Model/Bpmn.Model.csproj"
+            "src/Bpmn.Interchange/Bpmn.Interchange.csproj"
+            "src/Bpmn.Semantics/Bpmn.Semantics.csproj"
+            "src/Bpmn.Runtime.InMemory/Bpmn.Runtime.InMemory.csproj"
+          )
 
           for proj in "${projects[@]}"; do
             echo "Packing $proj..."
@@ -247,13 +239,16 @@ jobs:
           for nupkg in "${nupkgs[@]}"; do
             echo "Pushing $nupkg to NuGet.org..."
 
-            # A 403 on a package ID that does not exist yet almost always means the API key's glob
-            # pattern does not cover it, not that the key is wrong. Those have different fixes, so
-            # say which one this is rather than leaving a bare status code.
+            # A 403 on a package ID that does not exist yet almost always means the trusted publishing
+            # policy does not cover it, not that the token exchange failed - the key was issued, and
+            # nuget.org is refusing this ID specifically. Those have different fixes, so say which one
+            # this is rather than leaving a bare status code. Note the push is not atomic across
+            # packages: earlier ones in this loop are already live and cannot be unpublished, only
+            # delisted, so a 403 here leaves a partial release to finish rather than to retry blindly.
             if ! output=$(dotnet nuget push "$nupkg" --source "$NUGET_SOURCE" --api-key "$NUGET_API_KEY" --skip-duplicate 2>&1); then
               echo "$output"
               if echo "$output" | grep -q "403"; then
-                echo "::error::NuGet rejected the key for $(basename "$nupkg"). For a package ID that has never been published, the key needs the 'Push new packages and package versions' scope AND a glob pattern matching Bpmn.* . Check the key at https://www.nuget.org/account/apikeys ."
+                echo "::error::NuGet rejected $(basename "$nupkg"). For a package ID that has never been published, the trusted publishing policy at https://www.nuget.org/account/trustedpublishing must cover it - its package-ID pattern needs to match Bpmn.* , not just the IDs already published. Packages pushed earlier in this run are already live."
               fi
               exit 1
             fi

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- The single base version. CI reads this to compute preview and release package versions. -->
-    <Version>0.1.1</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## What

Bumps the base version to 0.2.0 and makes a tagged release pack **all four** packages instead of the interchange half. `Bpmn.Semantics` and `Bpmn.Runtime.InMemory` ship to nuget.org for the first time.

## Why

They were held back through all of 0.1.x, per the comment in `packages.yml` and [ADR 0002](docs/adr/0002-the-host-port-is-synchronous-and-command-returning.md). The reason was never that they were unfinished — it was that a port has no evidence behind it until something other than its own author implements it, and publishing an unvalidated port turns every fix to it into a breaking change against a public surface.

A second host has now implemented it, and produced better evidence than "it compiled": it found two real defects in the port — #13 (a cancelled transaction abandoning live work without a teardown, then restarting the same slot) and #15 (the same shape on the own-scope escalation activation). Both are fixed with coverage, and the second was found by looking where the first one pointed. That is what the hold-back was waiting for.

0.2.0 is also the semver-correct home for the payload format work already on `main`: #10 froze the format at 1.0.0 and normalized 53 property names, so state persisted by 0.1.x no longer deserializes. Pre-1.0 that belongs in a minor.

## Note on what this release actually ships

Worth stating plainly, since it is easy to assume otherwise: **#14 and #16 contribute nothing to what nuget.org gains from a 0.1.x perspective** — they are `Bpmn.Semantics` changes, and that package has never been on nuget.org. They shipped to the Feedz preview feed on merge (`0.1.1-preview.21`), which is where the downstream host consumes them. What is genuinely *new to nuget.org* here is `Bpmn.Semantics` and `Bpmn.Runtime.InMemory` as packages, plus #10's payload schema in `Bpmn.Model`.

## One stale line fixed while here

The 403 guidance still told the reader to check an API key's glob pattern at `nuget.org/account/apikeys`. That stopped being the fix when publishing moved to trusted publishing — the key is issued per-run, and a 403 means the *policy* does not cover the ID. It now names the policy page, and says that packages pushed earlier in the loop are already live, since the push is not atomic and nuget.org has no unpublish.

## ⚠️ Before publishing: check the trusted publishing policy

This is the first release to push package IDs that have **never existed** on nuget.org:

| Package | On nuget.org today |
|---|---|
| `Bpmn.Model` | 0.1.0, 0.1.1 |
| `Bpmn.Interchange` | 0.1.0, 0.1.1 |
| `Bpmn.Semantics` | **none** |
| `Bpmn.Runtime.InMemory` | **none** |

v0.1.0 already failed this way once — see `ci: explain a NuGet 403 instead of leaving a status code`. If the trusted publishing policy's package-ID pattern names only the two published IDs rather than `Bpmn.*`, the push will 403 on the two new ones **after** Model and Interchange are already live and unrecallable. Worth widening the pattern at https://www.nuget.org/account/trustedpublishing before creating the release.

## Checklist

- [x] `dotnet test Bpmn.slnx` passes — 346 tests
- [x] No host-specific references introduced
- [x] Public API changes are reflected in `docs/` — none; `docs/reference/packages.md` already said all four are versioned and released together, which this makes true rather than aspirational
- [x] A behavior change to the interpreter or reader/writer has a test that fails without it — n/a, packaging only
- [x] On-disk format unchanged — `BpmnPayloadFormat.Version` stays at 1.0.0, correctly independent of the package version it now differs from

Dry-run: packed all four locally at 0.2.0 — eight artifacts with symbols, dependency graph `InMemory -> Semantics -> Model` all pinned at 0.2.0, which is also the order the push loop uses.

## BPMN conformance

Untouched. MIWG corpus unchanged (86 passing).
